### PR TITLE
Add shebang to build-relationships.py

### DIFF
--- a/build/build-relationships.py
+++ b/build/build-relationships.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8; mode: python -*-
 
 import requests


### PR DESCRIPTION
The file is marked as  executable, but without telling the OS to run it using python, it just freezes. To options:
1. Make it no longer executable, so it's obvious you need to run `python build-relationships.py` (which still works)
2. Add a shebang so that it'll execute using Python automatically.

This commit implements "2.".