### PR TITLE
Adds envelope region functionality

### DIFF
--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1122,6 +1122,19 @@ buffer.
          (combobulate-skip-whitespace-forward))
        :reset-point-on-abort t))))
 
+(defun combobulate-envelop-region (template)
+  "Insert Combobulate TEMPLATE around NODE.
+
+If MARK-NODE is non-nil, then mark the node, which will then be
+available to tempo as the `r' identifier.  If nil, the region is
+kept as-is.
+
+POINT-PLACEMENT must be one of `start', `end', or `stay'. `stay'
+does not move point to either of NODE's boundaries."
+  (interactive)
+  (save-excursion
+    (combobulate-envelope-expand-instructions template)))
+
 (defun combobulate-envelop-node (template node mark-node point-placement)
   "Insert Combobulate TEMPLATE around NODE.
 
@@ -1160,24 +1173,27 @@ does not move point to either of NODE's boundaries."
   (when-let (env (combobulate-get-envelope-by-name name))
     (symbol-function (plist-get env :template-symbol))))
 
-(defun combobulate-apply-envelope (envelope &optional node)
-  "Envelop NODE near point with ENVELOPE.
+(defun combobulate-apply-envelope (envelope &optional node start end)
+  "Envelop NODE near point with ENVELOPE. If START and END are set,
+envelope region from START to END.
 
 Envelopes fail if point is not \"near\" NODE. Set FORCE to
 non-nil to override this check."
   (map-let (:nodes :mark-node :description :template :point-placement :name) envelope
     (unless (and name)
       (error "Envelope `%s' is not valid." envelope))
-    (with-navigation-nodes (:nodes nodes)
-      (if (setq node (or node (combobulate--get-nearest-navigable-node)))
-          (progn (combobulate-message "Enveloping" node "in" description)
-                 (combobulate-envelop-node
-                  template
-                  node
-                  mark-node
-                  point-placement))
-        (error "Cannot apply envelope `%s'. Point must be in one of \
-these nodes: `%s'." name nodes)))))
+    (if (and (not (equal start nil))  (not (equal end nil)))
+        (combobulate-envelop-region template)
+      (with-navigation-nodes (:nodes nodes)
+        (if (setq node (or node (combobulate--get-nearest-navigable-node)))
+            (progn (combobulate-message "Enveloping" node "in" description)
+                   (combobulate-envelop-node
+                    template
+                    node
+                    mark-node
+                    point-placement))
+          (error "Cannot apply envelope `%s'. Point must be in one of \
+these nodes: `%s'." name nodes))))))
 
 (defun combobulate-execute-envelope (envelope-name &optional node force)
   "Executes any envelope with a `:name' equal to ENVELOPE-NAME.
@@ -1188,68 +1204,74 @@ See `combobulate-apply-envelope' for more information."
     (unless envelope
       (error "There is no such envelope registered with the name `%s'"
              envelope-name))
-    (if node
-        (goto-char (cdr (combobulate-apply-envelope envelope node)))
-      (let ((combobulate-envelope-static t)
-            (envelope-nodes (plist-get envelope :nodes))
-            (change-group (prepare-change-group))
-            (undo-outer-limit nil)
-            (undo-limit most-positive-fixnum)
-            (undo-strong-limit most-positive-fixnum))
-        (unwind-protect
-            (progn
-              ;; use a change group to ensure we revert the proffered
-              ;; (and selected) choice immediately after. this is a
-              ;; hacky way of displaying an expansion (in conjunction
-              ;; with `combobulate-envelope-static' set to t) and not
-              ;; activate interactive prompts.
-              (activate-change-group change-group)
-              (setq chosen-node
-                    (combobulate-proffer-choices
-                     (seq-sort
-                      (lambda (a b)
-                        ;; "Smart" sorting that orders by largest node first but
-                        ;; *only* when the distance from `point' to the start of `a'
-                        ;; is 0 (i.e., the node starts at point.)
-                        ;;
-                        ;; For all other instances, we measure distance from point.
-                        (if (= (- (combobulate-node-start a) (point)) 0)
-                            (combobulate-node-larger-than-node-p a b)
-                          (> (- (combobulate-node-start a) (point))
-                             (- (combobulate-node-start b) (point)))))
-                      ;; if we don't have any assigned envelope nodes,
-                      ;; create a proxy node at point; that node (and
-                      ;; thus `point') will instead be where the
-                      ;; envelope is inserted.
-                      (if envelope-nodes
-                          (seq-filter (lambda (n)
-                                        (and (or force (combobulate-point-near-node n))
-                                             (member (combobulate-node-type n)
-                                                     envelope-nodes)))
-                                      (cons (combobulate-node-at-point)
-                                            (combobulate-get-parents (combobulate-node-at-point))))
-                        (list (combobulate-make-proxy-point-node))))
-                     (lambda (node mark-highlighted-fn _ mark-deleted-fn)
-                       ;; mark deleted and highlight first. That way when we apply
-                       ;; the envelope the overlays expand to match.
-                       (funcall mark-deleted-fn)
-                       (let ((ov (funcall mark-highlighted-fn)))
-                         (seq-let [[start &rest end] &rest pt]
-                             (combobulate-apply-envelope envelope node)
-                           (goto-char pt)
-                           ;; lil' hack. The extent of the node is not
-                           ;; the same as the envelope we just
-                           ;; applied.
-                           (move-overlay ov start end))))
-                     :reset-point-on-abort t
-                     :reset-point-on-accept nil))
-              (setq accepted t)
-              (cancel-change-group change-group))
-          (cancel-change-group change-group)))
-      ;; here we simply repeat what ever the selected choice was, as
-      ;; an explicit node skips the proffering process entirely.
-      (when (and chosen-node accepted)
-        (combobulate-execute-envelope envelope-name chosen-node)))))
+    (if (region-active-p)
+        (combobulate-apply-envelope
+         envelope
+         nil
+         (region-beginning)
+         (region-end))
+      (if node
+          (goto-char (cdr (combobulate-apply-envelope envelope node)))
+        (let ((combobulate-envelope-static t)
+              (envelope-nodes (plist-get envelope :nodes))
+              (change-group (prepare-change-group))
+              (undo-outer-limit nil)
+              (undo-limit most-positive-fixnum)
+              (undo-strong-limit most-positive-fixnum))
+          (unwind-protect
+              (progn
+                ;; use a change group to ensure we revert the proffered
+                ;; (and selected) choice immediately after. this is a
+                ;; hacky way of displaying an expansion (in conjunction
+                ;; with `combobulate-envelope-static' set to t) and not
+                ;; activate interactive prompts.
+                (activate-change-group change-group)
+                (setq chosen-node
+                      (combobulate-proffer-choices
+                       (seq-sort
+                        (lambda (a b)
+                          ;; "Smart" sorting that orders by largest node first but
+                          ;; *only* when the distance from `point' to the start of `a'
+                          ;; is 0 (i.e., the node starts at point.)
+                          ;;
+                          ;; For all other instances, we measure distance from point.
+                          (if (= (- (combobulate-node-start a) (point)) 0)
+                              (combobulate-node-larger-than-node-p a b)
+                            (> (- (combobulate-node-start a) (point))
+                               (- (combobulate-node-start b) (point)))))
+                        ;; if we don't have any assigned envelope nodes,
+                        ;; create a proxy node at point; that node (and
+                        ;; thus `point') will instead be where the
+                        ;; envelope is inserted.
+                        (if envelope-nodes
+                            (seq-filter (lambda (n)
+                                          (and (or force (combobulate-point-near-node n))
+                                               (member (combobulate-node-type n)
+                                                       envelope-nodes)))
+                                        (cons (combobulate-node-at-point)
+                                              (combobulate-get-parents (combobulate-node-at-point))))
+                          (list (combobulate-make-proxy-point-node))))
+                       (lambda (node mark-highlighted-fn _ mark-deleted-fn)
+                         ;; mark deleted and highlight first. That way when we apply
+                         ;; the envelope the overlays expand to match.
+                         (funcall mark-deleted-fn)
+                         (let ((ov (funcall mark-highlighted-fn)))
+                           (seq-let [[start &rest end] &rest pt]
+                               (combobulate-apply-envelope envelope node)
+                             (goto-char pt)
+                             ;; lil' hack. The extent of the node is not
+                             ;; the same as the envelope we just
+                             ;; applied.
+                             (move-overlay ov start end))))
+                       :reset-point-on-abort t
+                       :reset-point-on-accept nil))
+                (setq accepted t)
+                (cancel-change-group change-group))
+            (cancel-change-group change-group)))
+        ;; here we simply repeat what ever the selected choice was, as
+        ;; an explicit node skips the proffering process entirely.
+        (when (and chosen-node accepted)
+          (combobulate-execute-envelope envelope-name chosen-node))))))
 
 (defun combobulate-mark-node-at-point (&optional arg beginning-of-line)
   "Mark the most likely node on or near point ARG times.

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1167,8 +1167,10 @@ does not move point to either of NODE's boundaries."
     (symbol-function (plist-get env :template-symbol))))
 
 (defun combobulate-apply-envelope (envelope &optional node start end)
-  "Envelop NODE near point with ENVELOPE. If START and END are set,
-envelope region from START to END.
+  "Envelop NODE near point or region from START to END with ENVELOPE.
+
+If START and END are set, envelope region from START to END
+instead of NODE.
 
 Envelopes fail if point is not \"near\" NODE. Set FORCE to
 non-nil to override this check."

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1173,18 +1173,17 @@ does not move point to either of NODE's boundaries."
   (when-let (env (combobulate-get-envelope-by-name name))
     (symbol-function (plist-get env :template-symbol))))
 
-(defun combobulate-apply-envelope (envelope &optional node start end)
-  "Envelop NODE near point or region from START to END with ENVELOPE.
+(defun combobulate-apply-envelope (envelope &optional node region)
+  "Envelop NODE near point or active region with ENVELOPE.
 
-If START and END are set, envelope region from START to END
-instead of NODE.
+If REGION is t, envelope region instead of NODE.
 
 Envelopes fail if point is not \"near\" NODE. Set FORCE to
 non-nil to override this check."
   (map-let (:nodes :mark-node :description :template :point-placement :name) envelope
     (unless (and name)
       (error "Envelope `%s' is not valid." envelope))
-    (if (and (not (equal start nil))  (not (equal end nil)))
+    (if region
         (combobulate-envelop-region template)
       (with-navigation-nodes (:nodes nodes)
         (if (setq node (or node (combobulate--get-nearest-navigable-node)))
@@ -1207,11 +1206,7 @@ See `combobulate-apply-envelope' for more information."
       (error "There is no such envelope registered with the name `%s'"
              envelope-name))
     (if (region-active-p)
-        (combobulate-apply-envelope
-         envelope
-         nil
-         (region-beginning)
-         (region-end))
+        (combobulate-apply-envelope envelope nil t)
       (if node
           (goto-char (cdr (combobulate-apply-envelope envelope node)))
         (let ((combobulate-envelope-static t)

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1126,6 +1126,13 @@ buffer.
   "Insert Combobulate TEMPLATE around active region."
   (interactive)
   (save-excursion
+    ;; Reposition region so it starts and ends directly arround the
+    ;; code and not include additional white space or line brakes.
+    ;; Esp. important for white space sensitive languages.
+    (when (and (use-region-p) (> (point) (mark))) (exchange-point-and-mark))
+    (skip-chars-forward combobulate-skip-prefix-regexp)
+    (exchange-point-and-mark)
+    (skip-chars-backward combobulate-skip-prefix-regexp)
     (combobulate-envelope-expand-instructions template)))
 
 (defun combobulate-envelop-node (template node mark-node point-placement)

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1123,14 +1123,7 @@ buffer.
        :reset-point-on-abort t))))
 
 (defun combobulate-envelop-region (template)
-  "Insert Combobulate TEMPLATE around NODE.
-
-If MARK-NODE is non-nil, then mark the node, which will then be
-available to tempo as the `r' identifier.  If nil, the region is
-kept as-is.
-
-POINT-PLACEMENT must be one of `start', `end', or `stay'. `stay'
-does not move point to either of NODE's boundaries."
+  "Insert Combobulate TEMPLATE around active region."
   (interactive)
   (save-excursion
     (combobulate-envelope-expand-instructions template)))


### PR DESCRIPTION
Enveloping nodes is very helpful but often I want to envelope multiple nodes. The easiest way to do that might be to envelope a region. So these are changes to allow enveloping the active region.