### PR TITLE
Autoload combobulate-mode

### DIFF
--- a/combobulate.el
+++ b/combobulate.el
@@ -190,6 +190,7 @@ created."
 
 Customize `combobulate-setup-functions-alist' to change the language setup alist.")))
 
+;;;###autoload
 (define-minor-mode combobulate-mode "Navigate and edit text by syntactic constructs
 
 \\{combobulate-key-map}"


### PR DESCRIPTION
Adding an autoload for `combobulate-mode`, it makes the `combobulate-mode` function available after installing Combobulate with straight.el (and possibly other package managers).