### PR TITLE
Make combobulate--drag return node more accurate

### DIFF
--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1745,21 +1745,21 @@ Whether this function does anything or not depends on
   (when combobulate-manipulation-trim-empty-lines
     (delete-blank-lines)))
 
-(defun combobulate--drag (direction)
+(defun combobulate--drag (direction &optional node)
   "Perform a drag operation on the current navigation node in DIRECTION.
 
-If the current node has no siblings in the specified direction,
+If the current NODE has no siblings in the specified direction,
 an error is raised. If the operation is successful, the cursor is
 moved to the modified node."
   (let* ((up (eq direction 'up))
-         (node (or (combobulate--get-nearest-navigable-node) (error "No navigable node")))
-         (sibling (combobulate--get-sibling node (if up 'backward 'forward)))
-         (self (combobulate--get-sibling node 'self)))
+         (node (or node (combobulate--get-nearest-navigable-node) (error "No navigable node")))
+         (hash (combobulate--node-hash node))
+         (sibling (car (combobulate--get-directed-siblings node (if up 'backward 'forward)))))
     (unless sibling
       (error "No sibling node to swap with in that direction"))
     (combobulate--goto-node sibling)
-    (save-excursion (combobulate--swap-node-regions self sibling))
-    (combobulate--get-sibling (combobulate--get-nearest-navigable-node) 'self)))
+    (save-excursion (combobulate--swap-node-regions node sibling))
+    (combobulate--node-hash-get hash (combobulate-all-nodes-at-point))))
 
 (defun combobulate-baseline-indentation-default (pos)
   (save-excursion
@@ -1986,5 +1986,3 @@ beginning of the line."
 
 (provide 'combobulate-manipulation)
 ;;; combobulate-manipulation.el ends here
-
-

--- a/combobulate-navigation.el
+++ b/combobulate-navigation.el
@@ -111,6 +111,23 @@ If HIGHLIGHTED then the node is highlighted with
   "Return t if the current node at point is equal to NODE"
   (or (= (combobulate-node-start node) (point))))
 
+(defun combobulate--node-hash (node)
+  "Return a hash of NODE's length and its type, to create a
+semi-unique identifier."
+  (list (- (treesit-node-end node)
+           (treesit-node-start node))
+        (treesit-node-type node)))
+
+(defun combobulate--node-hash-get (hash nodes)
+  "Lookup HASH in NODES and return the node if found."
+  (let ((found nil)
+        (node))
+    (while (and (setq node (pop nodes))
+                (not found))
+      (when (equal hash (combobulate--node-hash node))
+        (setq found node)))
+    found))
+
 (defun combobulate-point-in-node-range-p (node)
   "Return t if point is contained between NODE's start and end positions"
   (and (>= (point) (combobulate-node-start node))
@@ -2032,4 +2049,3 @@ removed."
 
 (provide 'combobulate-navigation)
 ;;; combobulate-navigation.el ends here
-


### PR DESCRIPTION
While working on Go support I noticed that the return node of `combobulate--drag` is not always accurate. In Python it would return the expected node but in Go it did not.

Solution: Create a "hashing" function for nodes which uses a node's length and type as a unique identifier. With this we can find the exact node after it has been moved (through drag, maybe teleport through avy in the future?). Moving a node should not modify its length, only its position, therefore this should always work.

I also added `&optional node` as a suggestion. This is because own code uses `combobulate--drag` directly and i need it to accept a specific node rather than the node the cursor is currently on.