### PR TITLE
Allow configuration whether to descend into first list.

### DIFF
--- a/combobulate-navigation.el
+++ b/combobulate-navigation.el
@@ -1055,21 +1055,26 @@ continue by scanning in DIRECTION for any other contextual node (as per
            (combobulate-procedure-start-matches
             (combobulate--get-nearest-navigable-node))))
      ;; ... and if that fails, jump into the first list-like structure
-     ;; ahead of point.
+     ;; ahead of point (if enabled).
      ;;
      ;;
      ;; NOTE: this is a slightly modified version of `down-list' with
      ;; the syntax-ppss table check removed as it seems run into parse
      ;; errors in JSX files.
-     (ignore-errors
-       (let* ((arg 1)
-              (inc (if (> arg 0) 1 -1)))
-         (while (/= arg 0)
-           (goto-char (or (scan-lists (point) inc -1) (buffer-end arg)))
-           (setq arg (- arg inc))))))))
+     (and combobulate-navigate-down-into-lists
+          (ignore-errors
+            (let* ((arg 1)
+                   (inc (if (> arg 0) 1 -1)))
+              (while (/= arg 0)
+                (goto-char (or (scan-lists (point) inc -1) (buffer-end arg)))
+                (setq arg (- arg inc)))))))))
 
 (defun combobulate-navigate-down (&optional arg)
-  "Move down into the nearest navigable node ARG times"
+  "Move down into the nearest navigable node ARG times
+
+If `combobulate-navigate-down-into-lists' is enabled (the
+default) and no suitable node is found, jump instead into the
+first list-like structure ahead of point."
   (interactive "^p")
   (with-argument-repetition arg
     (combobulate-visual-move-to-node (combobulate--navigate-down))))
@@ -1824,4 +1829,3 @@ removed."
 
 (provide 'combobulate-navigation)
 ;;; combobulate-navigation.el ends here
-

--- a/combobulate-settings.el
+++ b/combobulate-settings.el
@@ -151,6 +151,12 @@ what a \"pair\" is."
   :type 'boolean
   :group 'combobulate)
 
+(defcustom combobulate-navigate-down-into-lists t
+  "Whether to navigate into the first list-like structure ahead
+of point in the absence of other suitable nodes."
+  :type 'boolean
+  :group 'combobulate)
+
 ;;; Group for cursor editing
 (defgroup combobulate-cursor nil
   "Settings for Combobulate's cursor editing."


### PR DESCRIPTION
When no node to descend into is found, by default combobulate-navigate-down instead jumps into first list-like structure ahead of the point.  This commit adds a custom to allow disabling of that behavior.

* combobulate-navigation.el (combobulate--navigate-down): Only descend into the first list-like structure if `combobulate-navigate-down-into-lists'. (combobulate-navigate-down): Describe the "jump into the first list-like" in the documentation string.
* combobulate-settings.el (combobulate-navigate-down-into-lists): New custom.