### PR TITLE
Add mhtml-ts-mode

### DIFF
--- a/combobulate-html.el
+++ b/combobulate-html.el
@@ -222,7 +222,7 @@
 (define-combobulate-language
  :name html
  :language html
- :major-modes (html-mode html-ts-mode mhtml-mode sgml-mode)
+ :major-modes (html-mode html-ts-mode mhtml-mode mhtml-ts-mode sgml-mode)
  :custom combobulate-html-definitions
  :setup-fn combobulate-html-setup)
 


### PR DESCRIPTION
This mode was defined in https://github.com/emacs-mirror/emacs/commit/05a96fd39809f11a3820e2164b23ebf9df192b13, a month ago.

I see that `:major-modes` works even when the user doesn't have the given mode installed, so merging this shouldn't cause any issues.

Also, I see that you have a development branch. Should PRs actually point to that instead?