### PR TITLE
Minor fix for build-relationships.py

### DIFF
--- a/build/build-relationships.py
+++ b/build/build-relationships.py
@@ -76,7 +76,7 @@ def match_rule(obj, rules):
             match child_type:
                 case {"named": True, "type": child_type}:
                     if child_type.startswith("_"):
-                        children |= rules[child_type][DEFAULT_FIELD_NAME]
+                        children |= rules[LispString(child_type)][DEFAULT_FIELD_NAME]
                     else:
                         children.add(LispString(child_type))
         return children


### PR DESCRIPTION
I discovered this while working on OCaml support for combobulate.

Running the codegen step for OCaml grammars results in invalid syntax for rules in combobulate-rules.el. Some of the rules e.g. _signed_constant don't produce quoted strings. 

```
...
 (_signed_constant (:*unnamed* ("signed_number" "unit" "character" "quoted_string" "string" "number" "boolean"))) 
 (_simple_class_expression (:*unnamed* ("class_path" "typed_class_expression" "parenthesized_class_expression" "extension" "quoted_extension" "object_expression" "instantiated_class"))) 
 ...
```

Using these versions of the OCaml treesitter grammar:
```
nodes = https://raw.githubusercontent.com/tree-sitter/tree-sitter-ocaml/v0.24.0/grammars/ocaml/src/node-types.json
grammar = https://raw.githubusercontent.com/tree-sitter/tree-sitter-ocaml/v0.24.0/grammars/ocaml/src/grammar.json
```

I also needed this same fix for Rust and Haskell grammars.