### PR TITLE
Change how the value of combobulate-key-prefix is set on the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,10 +275,10 @@ This is the basic setup for Combobulate. It assumes you have installed/can insta
 .. code-block:: elisp
 
     (use-package combobulate
-       :custom
+       :init
        ;; You can customize Combobulate's key prefix here.
        ;; Note that you may have to restart Emacs for this to take effect!
-       (combobulate-key-prefix "C-c o")
+       (setq combobulate-key-prefix "C-c o"))
        :hook ((prog-mode . combobulate-mode))
        ;; Amend this to the directory where you keep Combobulate's source
        ;; code.

--- a/combobulate-settings.el
+++ b/combobulate-settings.el
@@ -128,7 +128,7 @@ it finds, regardless of hierarchy."
   :type 'string
   :group 'combobulate)
 
-(defcustom combobulate-key-prefix "C-c o"
+(defcustom combobulate-key-prefix (if combobulate-key-prefix combobulate-key-prefix "C-c o")
   "Prefix key for Combobulate commands. Leave blank to disable.
 
 This is the prefix key for all Combobulate commands. It is


### PR DESCRIPTION
This fixes #117

Simply put, when the user sets `combobulate-key-prefix`, they are doing so after the keymap has already been created on lines 417-418 of `combobulate-setup.el`.

The user needs to set it up before `combobulate-setup.el` creates the keymap.