### PR TITLE
Fetch mickeynp/html-ts-mode.git as anonymous submodule instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/html-ts-mode"]
 	path = tests/html-ts-mode
-	url = git@github.com:mickeynp/html-ts-mode.git
+	url = https://github.com/mickeynp/html-ts-mode.git


### PR DESCRIPTION
Hello,

Running Emacs in a Docker container, Combobulate generates this error on packaging installation by straight.el:
```txt
184.4     > Cloning combobulate...
184.4     ! Failed git clone operation, retrying (attempt 2/3)...
184.4     ! Failed git clone operation, retrying (attempt 3/3)...
184.4     x The package manager threw an error
184.4     x Last 16 lines of straight's error log:
184.4       
184.4       $ cd /home/pimacs/.emacs.d/.local/straight/repos/combobulate/
184.4       $ git submodule update --init --recursive
184.4       
184.4       Submodule 'tests/html-ts-mode' (git@github.com:mickeynp/html-ts-mode.git) registered for path 'tests/html-ts-mode'
184.4       Cloning into '/home/pimacs/.emacs.d/.local/straight/repos/combobulate/tests/html-ts-mode'...
184.4       hostkeys_find_by_key_hostfile: hostkeys_foreach failed for /home/pimacs/.ssh/known_hosts: Permission denied
184.4       Host key verification failed.
184.4       fatal: Could not read from remote repository.
184.4       
184.4       Please make sure you have the correct access rights
184.4       and the repository exists.
184.4       fatal: clone of 'git@github.com:mickeynp/html-ts-mode.git' into submodule path '/home/pimacs/.emacs.d/.local/straight/repos/combobulate/tests/html-ts-mode' failed
184.4       Failed to clone 'tests/html-ts-mode'. Retry scheduled
184.4       Cloning into '/home/pimacs/.emacs.d/.local/straight/repos/combobulate/tests/html-ts-mode'...
184.4       hostkeys_find_by_key_hostfile: hostkeys_foreach failed for /home/pimacs/.ssh/known_hosts: Permission denied
184.4       Host key verification failed.
184.4       fatal: Could not read from remote repository.
184.4       
184.4       Please make sure you have the correct access rights
184.4       and the repository exists.
184.4       fatal: clone of 'git@github.com:mickeynp/html-ts-mode.git' into submodule path '/home/pimacs/.emacs.d/.local/straight/repos/combobulate/tests/html-ts-mode' failed
184.4       Failed to clone 'tests/html-ts-mode' a second time, aborting
184.4       
184.4       [Return code: 1]
```
In addition to correcting the error it seems more suitable to use an anonymous access for a public repository.

Regards