### PR TITLE
Add `?` to the end of predicates

### DIFF
--- a/combobulate-query.el
+++ b/combobulate-query.el
@@ -529,8 +529,8 @@ Rewrites `:match' to `#match', etc. along the way."
                    ;; `.' is the anchor in the real query language,
                    ;; but `:anchor' in elisp forms.
                    `((":anchor" . ".")
-                     ;; Fix up `:match' to `#match', etc.
-                     (,(rx ":" (group (| "match" "pred" "eq"))) . "#\\1")))
+                     ;; Fix up `:match' to `#match?', etc.
+                     (,(rx ":" (group (| "match" "pred" "eq"))) . "#\\1?")))
       (setq tgt-query (replace-regexp-in-string before after tgt-query)))
     (string-trim tgt-query)))
 


### PR DESCRIPTION
This fixes the error appearing during font lock, on Emacs 31:

> Error during redisplay: (jit-lock-function 1) signaled
> (treesit-query-error "Invalid predicate" "match" "Currently Emacs
> only supports `equal', `match', and `pred' predicates")

See tree-sitter/tree-sitter#4490. Predicates are now required to end with `?`.

Also see: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79687

This post helped me to debug the issue:
https://mwolson.org/blog/2026-04-20-fixing-typescript-ts-mode-in-emacs-30-2/