### PR TITLE
Configurable variable for minor-mode lighter

### DIFF
--- a/combobulate-setup.el
+++ b/combobulate-setup.el
@@ -527,6 +527,11 @@ MINOR-MODE-FN is the minor mode function for this language."
     (push (list language major-modes minor-mode-fn)
           combobulate-registered-languages-alist)))
 
+(defcustom combobulate-mode-lighter "©"
+  "Lighter displayed in mode line when `combobulate-mode' is enabled."
+  :group 'combobulate
+  :type 'string)
+
 (cl-defmacro define-combobulate-language (&key name
                                                major-modes (custom nil)
                                                setup-fn
@@ -626,7 +631,7 @@ support where you still want to use Combobulate's features."
           (push `(define-minor-mode ,minor-mode-fn
                    ,(format "Combobulate minor mode for the `%s' tree-sitter language." name)
                    :init-value nil
-                   :lighter "©"
+                   :lighter combobulate-mode-lighter
                    :keymap ,language-keymap
                    ;; Recycle `combobulate-mode' as the variable used
                    ;; to store the toggle state of this minor mode


### PR DESCRIPTION
I the lighter currently is set to ©, without a space separating it from the preceding minor mode, which is non-conventional. I personally would rather use something like " Combo" instead, therefore this configuration option. I've left the default on ©, as is currently.

Even though the lighter is set inside the `define-combobulate` language macro, to my surprise using a `defcustom` variable, and setting it in the `:custom` section of `use-package` still seems to work fine. Not sure if there are edge-cases where it would be necessary to set it manually upfront in the `:init` section instead.