### PR TITLE
Add Docker-backed Emacs CI with ERT reporting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 Dockerfile
 *.elc
 .git/
+.github/
+.emacs.d/
+test-results/
 .pytest_cache/
 *.pyc
+*~
 \#*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Changes to CI trust boundaries require explicit owner review.
+/.github/ @mickeynp
+/.gitmodules @mickeynp
+/Dockerfile @mickeynp
+/Makefile @mickeynp
+/tests/.ts-*.el @mickeynp
+/tests/generate-harnesses.el @mickeynp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,139 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - development
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Emacs ${{ matrix.emacs-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - "29.4"
+          - "30.2"
+
+    env:
+      IMAGE_NAME: combobulate-test:${{ matrix.emacs-version }}
+      ERT_REPORT: test-results/emacs-${{ matrix.emacs-version }}/ert
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}
+          build-args: |
+            EMACS_VERSION=${{ matrix.emacs-version }}
+          cache-from: type=gha,scope=emacs-${{ matrix.emacs-version }}
+          cache-to: type=gha,mode=max,scope=emacs-${{ matrix.emacs-version }}
+
+      - name: Verify Emacs and tree-sitter grammars
+        run: |
+          docker run --rm --entrypoint emacs "$IMAGE_NAME" \
+            --batch --no-init-file \
+            --eval '(progn
+              (princ (format "Emacs %s; tree-sitter=%S\n"
+                             emacs-version (treesit-available-p)))
+              (unless (treesit-available-p)
+                (error "Emacs was built without tree-sitter support"))
+              (dolist (language (quote (css dockerfile go html javascript json
+                                        python toml tsx typescript yaml)))
+                (unless (treesit-language-available-p language)
+                  (error "Missing %s grammar" language))))'
+
+      - name: Run ERT suite
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/test-results"
+          docker run --rm \
+            --env "ERT_JUNIT_FILE=/workspace/$ERT_REPORT" \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$IMAGE_NAME" run-tests-junit
+
+      - name: Upload ERT results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ert-results-${{ matrix.emacs-version }}
+          path: ${{ env.ERT_REPORT }}.xml
+          if-no-files-found: error
+          retention-days: 14
+
+      # Fork pull requests retain the JUnit artifact but cannot create checks
+      # because GitHub downgrades their token to read-only permissions.
+      - name: Publish ERT results
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: ERT / Emacs ${{ matrix.emacs-version }}
+          path: ${{ env.ERT_REPORT }}.xml
+          reporter: java-junit
+          use-actions-summary: true
+          list-suites: all
+          list-tests: failed
+          max-annotations: 20
+          fail-on-empty: true
+          fail-on-error: true
+
+      - name: Run load-path installation smoke test
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$IMAGE_NAME" tests/.ts-loadpath.el
+
+      # These installers deliberately clone the development branch, so only run
+      # them when that remote branch contains the revision under test.
+      - name: Run straight.el installation smoke test
+        if: github.ref == 'refs/heads/development' && matrix.emacs-version == '29.4'
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$IMAGE_NAME" tests/.ts-straight.el
+
+      - name: Run use-package :vc installation smoke test
+        if: github.ref == 'refs/heads/development' && matrix.emacs-version == '30.2'
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$IMAGE_NAME" tests/.ts-use-package-vc.el
+
+      - name: Regenerate test harnesses
+        if: matrix.emacs-version == '29.4'
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "$IMAGE_NAME" build-tests
+
+      - name: Check generated test harnesses
+        if: matrix.emacs-version == '29.4'
+        run: git diff --exit-code -- tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             --pids-limit 512 \
             --memory 2g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --entrypoint emacs \
             "$IMAGE_NAME" \
             --batch --no-init-file \
@@ -88,6 +89,7 @@ jobs:
             --pids-limit 512 \
             --memory 4g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --env "ERT_JUNIT_FILE=/workspace/$ERT_REPORT" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
@@ -110,6 +112,7 @@ jobs:
             --pids-limit 512 \
             --memory 4g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-loadpath.el
@@ -125,6 +128,7 @@ jobs:
             --pids-limit 512 \
             --memory 4g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-straight.el
@@ -138,6 +142,7 @@ jobs:
             --pids-limit 512 \
             --memory 4g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-use-package-vc.el
@@ -152,6 +157,7 @@ jobs:
             --pids-limit 512 \
             --memory 4g \
             --cpus 2 \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" build-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
           name: ERT / Emacs ${{ matrix.emacs-version }}
           path: ${{ env.ERT_REPORT }}.xml
           reporter: java-junit
-          use-actions-summary: true
           list-suites: all
           list-tests: failed
           max-annotations: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           name: ERT / Emacs ${{ matrix.emacs-version }}
           path: ${{ env.ERT_REPORT }}.xml
           reporter: java-junit
+          use-actions-summary: false
           list-suites: all
           list-tests: failed
           max-annotations: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +20,8 @@ jobs:
     name: Emacs ${{ matrix.emacs-version }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -32,30 +33,40 @@ jobs:
     env:
       IMAGE_NAME: combobulate-test:${{ matrix.emacs-version }}
       ERT_REPORT: test-results/emacs-${{ matrix.emacs-version }}/ert
+      CACHE_SCOPE: emacs-${{ matrix.emacs-version }}-${{ github.base_ref || github.ref_name }}
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build the test image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           load: true
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
             EMACS_VERSION=${{ matrix.emacs-version }}
-          cache-from: type=gha,scope=emacs-${{ matrix.emacs-version }}
-          cache-to: type=gha,mode=max,scope=emacs-${{ matrix.emacs-version }}
+          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}', env.CACHE_SCOPE) || '' }}
 
       - name: Verify Emacs and tree-sitter grammars
         run: |
-          docker run --rm --entrypoint emacs "$IMAGE_NAME" \
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 2g \
+            --cpus 2 \
+            --entrypoint emacs \
+            "$IMAGE_NAME" \
             --batch --no-init-file \
             --eval '(progn
               (princ (format "Emacs %s; tree-sitter=%S\n"
@@ -71,6 +82,12 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/test-results"
           docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 4g \
+            --cpus 2 \
             --env "ERT_JUNIT_FILE=/workspace/$ERT_REPORT" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
@@ -85,25 +102,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      # Fork pull requests retain the JUnit artifact but cannot create checks
-      # because GitHub downgrades their token to read-only permissions.
-      - name: Publish ERT results
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: ERT / Emacs ${{ matrix.emacs-version }}
-          path: ${{ env.ERT_REPORT }}.xml
-          reporter: java-junit
-          use-actions-summary: false
-          list-suites: all
-          list-tests: failed
-          max-annotations: 20
-          fail-on-empty: true
-          fail-on-error: true
-
       - name: Run load-path installation smoke test
         run: |
           docker run --rm \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 4g \
+            --cpus 2 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-loadpath.el
@@ -114,6 +120,11 @@ jobs:
         if: github.ref == 'refs/heads/development' && matrix.emacs-version == '29.4'
         run: |
           docker run --rm \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 4g \
+            --cpus 2 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-straight.el
@@ -122,6 +133,11 @@ jobs:
         if: github.ref == 'refs/heads/development' && matrix.emacs-version == '30.2'
         run: |
           docker run --rm \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 4g \
+            --cpus 2 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" tests/.ts-use-package-vc.el
@@ -130,6 +146,12 @@ jobs:
         if: matrix.emacs-version == '29.4'
         run: |
           docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 4g \
+            --cpus 2 \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "$IMAGE_NAME" build-tests
@@ -137,3 +159,45 @@ jobs:
       - name: Check generated test harnesses
         if: matrix.emacs-version == '29.4'
         run: git diff --exit-code -- tests
+
+  # Never execute pull-request code in this job. It alone can create Checks and
+  # consumes only the exact JUnit artifact emitted by the unprivileged test job.
+  report:
+    name: Publish ERT / Emacs ${{ matrix.emacs-version }}
+    needs: test
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - "29.4"
+          - "30.2"
+
+    steps:
+      - name: Download ERT results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ert-results-${{ matrix.emacs-version }}
+          path: test-results/emacs-${{ matrix.emacs-version }}
+
+      - name: Publish ERT results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: ERT / Emacs ${{ matrix.emacs-version }}
+          path: test-results/emacs-${{ matrix.emacs-version }}/ert.xml
+          reporter: java-junit
+          use-actions-summary: false
+          list-suites: all
+          list-tests: failed
+          # ERT does not include source paths, so annotations would require a
+          # privileged checkout without improving the report.
+          max-annotations: 0
+          fail-on-empty: true
+          fail-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ flycheck*
 /.envrc
 /.emacs.d/
 /tests/.emacs.d/
+/test-results/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/html-ts-mode"]
 	path = tests/html-ts-mode
-	url = git@github.com:mickeynp/html-ts-mode.git
+	url = https://github.com/mickeynp/html-ts-mode.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,57 @@
-FROM ubuntu:24.04 as base
+# syntax=docker/dockerfile:1
+FROM ubuntu:24.04
 
-ENV VERSION=29.1 \
-    FOO=1
-# We assume the git repo's cloned outside and copied in, instead of
-# cloning it in here. But that works, too.
-WORKDIR /opt/emacs
-LABEL MAINTAINER="Mickey Petersen at mastering emacs" \
-      FOO="bar"
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get build-dep -y emacs
-
-# Needed for add-apt-repository, et al.
-#
-# If you're installing this outside Docker you may not need this.
 RUN apt-get update \
-    && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common \
-    wget \
-    git \
-    libtree-sitter-dev \
-    libtree-sitter0 \
-    tree-sitter-cli
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libgnutls28-dev \
+        libjansson-dev \
+        libncurses-dev \
+        libtree-sitter-dev \
+        libxml2-dev \
+        pkg-config \
+        texinfo \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Download and extract Emacs
-RUN wget https://ftp.gnu.org/gnu/emacs/emacs-$VERSION.tar.gz \
-    && tar -xf emacs-$VERSION.tar.gz \
-    && rm emacs-$VERSION.tar.gz
+ARG EMACS_VERSION=29.4
+ARG JOBS=4
 
-WORKDIR /opt/emacs/emacs-$VERSION/
+ENV EMACS_VERSION=${EMACS_VERSION}
 
-# Configure and run
-RUN ./autogen.sh \
-    && ./configure \
-    --with-tree-sitter
+WORKDIR /opt/emacs
 
-RUN make -j ${JOBS} \
+RUN curl --fail --location --remote-name \
+        "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.xz" \
+    && tar --extract --file "emacs-${EMACS_VERSION}.tar.xz" \
+    && rm "emacs-${EMACS_VERSION}.tar.xz"
+
+WORKDIR /opt/emacs/emacs-${EMACS_VERSION}
+
+RUN ./configure \
+        --without-native-compilation \
+        --without-x \
+        --with-gnutls \
+        --with-tree-sitter \
+        --with-xml2 \
+    && make -j "${JOBS}" \
     && make install \
-    && cd \
-    && rm -rf /opt/emacs/emacs-$VERSION/
-ENV JOBS=4
+    && rm -rf "/opt/emacs/emacs-${EMACS_VERSION}"
 
 WORKDIR /opt
 
-# Install the grammars
-COPY .ts-setup.el /opt
-RUN emacs --batch -L $PWD -l .ts-setup.el
+# Keep grammar compilation cached independently from ordinary source changes.
+COPY tests/.ts-setup.el /opt/tests/.ts-setup.el
+COPY tests/html-ts-mode/html-ts-mode.el /opt/tests/html-ts-mode/html-ts-mode.el
+RUN emacs --batch --no-init-file -L /opt -l /opt/tests/.ts-setup.el
 
 COPY . /opt/
-RUN cd /opt/
-ENTRYPOINT ["make",  "foo"]
 
+ENTRYPOINT ["make"]
+CMD ["run-tests"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,16 @@ RUN ./configure \
 
 WORKDIR /opt
 
+# Keep prebuilt grammars readable when CI maps the container to its unprivileged
+# runner UID. A fixed HOME also works when that UID has no passwd entry.
+ENV HOME=/opt/combobulate-home
+RUN mkdir -p "${HOME}"
+
 # Keep grammar compilation cached independently from ordinary source changes.
 COPY tests/.ts-setup.el /opt/tests/.ts-setup.el
 COPY tests/html-ts-mode/html-ts-mode.el /opt/tests/html-ts-mode/html-ts-mode.el
-RUN emacs --batch --no-init-file -L /opt -l /opt/tests/.ts-setup.el
+RUN emacs --batch --no-init-file -L /opt -l /opt/tests/.ts-setup.el \
+    && chmod -R a+rX "${HOME}"
 
 COPY . /opt/
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 IMG ?= combobulate
 TAG ?= dev
+EMACS_VERSION ?= 29.4
+JOBS ?= 4
 DOCKER_CMD ?= docker run --rm -w /opt/ $(DOCKER_ARGS) $(IMG):$(TAG)
 EMACS_BIN ?= emacs
+ERT_JUNIT_FILE ?= $(CURDIR)/test-results/ert
 # Name of the directory where the Emacs setup is installed.
 INIT_NAME := .emacs.d/
 # Directory where the Emacs setup and TS installations take place.
-TMP_INIT_DIR := $(PWD)/$(INIT_NAME)
+TMP_INIT_DIR := $(CURDIR)/$(INIT_NAME)
 # Baseline command for running tests.
 EMACS_CMD = $(EMACS_BIN) --batch  --no-init-file --chdir ./tests/  -L ..  -L .  -l tests/.ts-setup.el
 
@@ -21,9 +24,9 @@ byte-compile: clean-elc
 	$(EMACS_BIN) \
 	--no-init-file \
 	--batch \
-	--directory $(PWD) \
+	--directory $(CURDIR) \
 	--funcall batch-byte-compile \
-	$(PWD) \
+	$(CURDIR) \
 	*.el
 
 .PHONY:	rebuild-relationships
@@ -49,13 +52,21 @@ build-tests: clean-tests
 
 
 ELFILES := $(sort $(shell find ./tests/ -name "test-*.el" ! -name ".*" -print))
+ERT_TEST_ARGS = $(patsubst %,-l %,$(ELFILES:.el=)) \
+	--eval "(setq ert-summarize-tests-batch-and-exit nil)" \
+	-f 'ert-run-tests-batch-and-exit'
 
 .PHONY:	run-tests
 run-tests: byte-compile
+	$(EMACS_CMD) -l ert $(ERT_TEST_ARGS)
+
+.PHONY:	run-tests-junit
+run-tests-junit: byte-compile
+	mkdir -p "$(dir $(ERT_JUNIT_FILE))"
+	EMACS_TEST_JUNIT_REPORT="$(ERT_JUNIT_FILE)" \
 	$(EMACS_CMD) -l ert \
-	$(patsubst %,-l %,$(ELFILES:.el=)) \
-	--eval "(setq ert-summarize-tests-batch-and-exit nil)" \
-	-f 'ert-run-tests-batch-and-exit'
+	--eval '(setq ert-load-file-name "$(ERT_JUNIT_FILE)")' \
+	$(ERT_TEST_ARGS)
 
 
 
@@ -66,7 +77,10 @@ clean-install-tests:
 
 .PHONY:	docker-build
 docker-build:
-	docker build -t $(IMG):$(TAG) .
+	docker build \
+		--build-arg EMACS_VERSION=$(EMACS_VERSION) \
+		--build-arg JOBS=$(JOBS) \
+		-t $(IMG):$(TAG) .
 
 .PHONY:	docker-build-tests
 docker-build-tests: docker-build

--- a/tests/.ts-setup.el
+++ b/tests/.ts-setup.el
@@ -8,7 +8,7 @@
          (json . ("https://github.com/tree-sitter/tree-sitter-json" "v0.20.2"))
          (go . ("https://github.com/tree-sitter/tree-sitter-go" "v0.20.0"))
          (python . ("https://github.com/tree-sitter/tree-sitter-python" "v0.20.4"))
-         (toml "https://github.com/tree-sitter/tree-sitter-toml")
+         (toml . ("https://github.com/tree-sitter/tree-sitter-toml" "v0.5.1"))
          (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "tsx/src"))
          (typescript . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "typescript/src"))
          (yaml . ("https://github.com/ikatyang/tree-sitter-yaml" "v0.5.0")))))

--- a/tests/generate-harnesses.el
+++ b/tests/generate-harnesses.el
@@ -117,7 +117,7 @@
                   :instructions
                   ("{" @ "null" >
                    n > " ? " @ (choice* :name "consequence" :missing ("null") :rest (r>))
-                   n > " : " (choice* :name "alternative" :missing ("<" (p other "SOME TAG") "/>") :rest (r>))
+                   n "  : " (choice* :name "alternative" :missing ("<" (p other "SOME TAG") "/>") :rest (r>))
                    n > "}" >)
                   :mock-proffer-choices (0 0)
                   :mock-registers ((region . "<div>Some jsx element</div>"))

--- a/tests/test-combobulate-envelope-expand-instructions.gen.el
+++ b/tests/test-combobulate-envelope-expand-instructions.gen.el
@@ -469,7 +469,7 @@
 				("null")
 				:rest
 				(r>))
-		       n > " : "
+		       n "  : "
 		       (choice* :name "alternative" :missing
 				("<"
 				 (p other "SOME TAG")


### PR DESCRIPTION
## Summary

- add a Docker-backed GitHub Actions matrix for Emacs 29.4 and 30.2
- build and verify all eleven required tree-sitter grammars in each matrix lane
- export the 695-test ERT suite through Emacs's built-in JUnit support
- publish per-version `ERT / Emacs …` GitHub Checks and retain XML artifacts for 14 days, including after test failures
- keep fork pull requests safe by retaining artifacts while skipping check creation when the token is read-only
- run load-path installation smoke tests in both lanes, branch-only straight.el and `use-package :vc` installer tests, and generated-harness drift detection
- parameterize the Dockerfile, pin the TOML grammar, use HTTPS for the `html-ts-mode` submodule, and stabilize the Emacs 30 generated fixture

## Local validation

- rebuilt the final Docker image for Emacs 29.4 and Emacs 30.2
- verified tree-sitter support and all eleven grammars in both images
- passed all 695 ERT tests on both versions
- parsed both final JUnit reports: 695 cases, 0 failures, 0 errors, 0 skips
- verified a representative ERT failure produces assertion details in JUnit while preserving a nonzero `make` exit status
- passed load-path installation smoke tests on both versions
- regenerated test harnesses with Emacs 29.4 and confirmed the checked-in generated fixture remains aligned
- passed `actionlint` 1.7.12 and `git diff --check`

## CI hardening

- run contributor-controlled tests with only `contents: read`, no persisted checkout credentials, no secrets/OIDC, and no self-hosted infrastructure
- run Docker test containers as the hosted runner UID/GID with all capabilities dropped, `no-new-privileges`, PID/CPU/memory limits, and no network for tests that do not need it
- isolate `checks: write` in a separate reporting matrix that never checks out or executes repository code; fork PRs retain JUnit artifacts but skip privileged Check publication
- SHA-pin all six Actions, digest-pin Ubuntu 24.04, allow only GitHub-owned Actions plus the required Docker and `dorny/test-reporter` Actions, and enforce full-SHA references at repository level
- permit pull requests to read Buildx caches but reserve reusable cache writes for trusted pushes
- protect security-sensitive paths with CODEOWNERS and schedule Dependabot updates for Actions, Docker, and Git submodules
- require approval for every external contributor, keep default workflow tokens read-only, disable Actions PR approvals, and enable vulnerability alerts, Dependabot security fixes, secret scanning, and push protection
- protect `master` and `development` with an active ruleset requiring PRs, one approval, stale-review dismissal, Code Owner review, resolved threads, and strict current `Emacs 29.4` / `Emacs 30.2` checks; the repository administrator has only a PR-scoped bypass

## Hardened revision validation

- passed `actionlint` 1.7.12, immutable-reference checks, YAML parsing, and `git diff --check`
- rebuilt both digest-pinned images and verified all eleven grammars as an unprivileged UID without network or capabilities
- passed both 695-test ERT suites under the final sandbox, with JUnit reports showing 695 tests and zero failures/errors/skips per version
- passed load-path, straight.el, and `use-package :vc` installation probes plus generated-harness drift detection
