### PR TITLE
Keep skipped ERT report check readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
   # Never execute pull-request code in this job. It alone can create Checks and
   # consumes only the exact JUnit artifact emitted by the unprivileged test job.
   report:
-    name: Publish ERT / Emacs ${{ matrix.emacs-version }}
+    # GitHub evaluates this job's trust gate before expanding its matrix. Keep
+    # the job name static so skipped fork-PR runs never expose a raw expression.
+    name: Publish ERT checks
     needs: test
     if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- use a static, human-readable name for the gated ERT publishing job
- prevent GitHub from showing the unresolved matrix variable when it skips reporting on fork pull requests
- preserve versioned ERT report checks and the existing no-checkout trust boundary

## Validation
- actionlint 1.7.12
- git diff --check
- static assertions for the report name, versioned reporter names, checks permission, and fork trust gate
