### PR TITLE
Add source-built Emacs 31.x CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs-version:
-          - "29.4"
-          - "30.2"
+        include:
+          - emacs-version: "29.4"
+            emacs-source-ref: ""
+          - emacs-version: "30.2"
+            emacs-source-ref: ""
+          # Track the prerelease branch honestly as 31.x until GNU publishes
+          # refs/tags/emacs-31.1, then switch this row to 31.1 and that tag.
+          # A future emacs-32 lane needs only another source-backed matrix row.
+          - emacs-version: "31.x"
+            emacs-source-ref: refs/heads/emacs-31
 
     env:
       IMAGE_NAME: combobulate-test:${{ matrix.emacs-version }}
       ERT_REPORT: test-results/emacs-${{ matrix.emacs-version }}/ert
-      CACHE_SCOPE: emacs-${{ matrix.emacs-version }}-${{ github.base_ref || github.ref_name }}
 
     steps:
       - name: Check out the repository
@@ -41,6 +47,43 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+
+      - name: Resolve Emacs source revision
+        id: emacs-source
+        env:
+          EMACS_SOURCE_REF: ${{ matrix.emacs-source-ref }}
+          # Established read-only mirror of the canonical Savannah repository.
+          EMACS_SOURCE_REPOSITORY: https://github.com/emacs-mirror/emacs.git
+        run: |
+          set -euo pipefail
+          cache_key="emacs-${{ matrix.emacs-version }}"
+          source_sha=""
+
+          if [[ -n "$EMACS_SOURCE_REF" ]]; then
+            case "$EMACS_SOURCE_REF" in
+              refs/heads/*|refs/tags/*) ;;
+              *) echo "Unsupported Emacs source ref: $EMACS_SOURCE_REF" >&2; exit 1 ;;
+            esac
+
+            resolution="$(git ls-remote --exit-code \
+              "$EMACS_SOURCE_REPOSITORY" \
+              "$EMACS_SOURCE_REF" "${EMACS_SOURCE_REF}^{}")"
+            source_sha="$(awk -v ref="$EMACS_SOURCE_REF" '
+              $2 == ref { direct = $1 }
+              $2 == ref "^{}" { peeled = $1 }
+              END { if (peeled) print peeled; else if (direct) print direct }
+            ' <<< "$resolution")"
+
+            if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Could not resolve $EMACS_SOURCE_REF to a full commit SHA" >&2
+              exit 1
+            fi
+            cache_key="${cache_key}-${source_sha}"
+            echo "Resolved $EMACS_SOURCE_REF to $source_sha"
+          fi
+
+          printf 'sha=%s\n' "$source_sha" >> "$GITHUB_OUTPUT"
+          printf 'cache-key=%s\n' "$cache_key" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -53,8 +96,10 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}
           build-args: |
             EMACS_VERSION=${{ matrix.emacs-version }}
-          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
-          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}', env.CACHE_SCOPE) || '' }}
+            EMACS_SOURCE_REF=${{ matrix.emacs-source-ref }}
+            EMACS_SOURCE_SHA=${{ steps.emacs-source.outputs.sha }}
+          cache-from: type=gha,scope=${{ steps.emacs-source.outputs.cache-key }}-${{ github.base_ref || github.ref_name }}
+          cache-to: ${{ github.event_name == 'push' && format('type=gha,mode=max,scope={0}-{1}', steps.emacs-source.outputs.cache-key, github.ref_name) || '' }}
 
       - name: Verify Emacs and tree-sitter grammars
         run: |
@@ -79,6 +124,24 @@ jobs:
                                         tsx typescript yaml)))
                 (unless (treesit-language-available-p language)
                   (error "Missing %s grammar" language))))'
+
+      - name: Run load-path smoke test
+        run: |
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 512 \
+            --memory 2g \
+            --cpus 2 \
+            --user "$(id -u):$(id -g)" \
+            --entrypoint emacs \
+            "$IMAGE_NAME" \
+            --batch --no-init-file --directory /opt \
+            --eval '(progn
+              (require (quote combobulate))
+              (unless (featurep (quote combobulate))
+                (error "Combobulate did not load from /opt")))'
 
       - name: Run ERT suite
         run: |
@@ -145,6 +208,7 @@ jobs:
         emacs-version:
           - "29.4"
           - "30.2"
+          - "31.x"
 
     steps:
       - name: Download ERT results

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        autoconf \
         build-essential \
         ca-certificates \
         curl \
@@ -21,18 +22,51 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG EMACS_VERSION=29.4
+ARG EMACS_SOURCE_REF
+ARG EMACS_SOURCE_SHA
 ARG JOBS=4
 
 ENV EMACS_VERSION=${EMACS_VERSION}
 
 WORKDIR /opt/emacs
 
-RUN curl --fail --location --remote-name \
-        "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.xz" \
-    && tar --extract --file "emacs-${EMACS_VERSION}.tar.xz" \
-    && rm "emacs-${EMACS_VERSION}.tar.xz"
+# Release lanes use GNU tarballs. Prerelease lanes use the established
+# read-only Emacs mirror and supply both a named ref and its separately resolved
+# full commit SHA; consuming the SHA here also makes it part of the Docker layer
+# cache identity.
+RUN set -eu; \
+    mkdir emacs-source; \
+    if [ -n "${EMACS_SOURCE_REF}" ] || [ -n "${EMACS_SOURCE_SHA}" ]; then \
+        test -n "${EMACS_SOURCE_REF}"; \
+        test -n "${EMACS_SOURCE_SHA}"; \
+        case "${EMACS_SOURCE_REF}" in \
+            refs/heads/*|refs/tags/*) ;; \
+            *) echo "Unsupported Emacs source ref: ${EMACS_SOURCE_REF}" >&2; exit 1 ;; \
+        esac; \
+        printf '%s\n' "${EMACS_SOURCE_SHA}" | grep -Eq '^[0-9a-f]{40}$'; \
+        git -C emacs-source init --quiet; \
+        git -C emacs-source remote add origin \
+            https://github.com/emacs-mirror/emacs.git; \
+        git -C emacs-source -c protocol.version=2 fetch \
+            --depth 1 --no-tags origin "${EMACS_SOURCE_REF}"; \
+        fetched_sha="$(git -C emacs-source rev-parse 'FETCH_HEAD^{commit}')"; \
+        if [ "${fetched_sha}" != "${EMACS_SOURCE_SHA}" ]; then \
+            echo "Resolved ${EMACS_SOURCE_REF} to ${EMACS_SOURCE_SHA}, but fetched ${fetched_sha}" >&2; \
+            exit 1; \
+        fi; \
+        git -C emacs-source checkout --quiet --detach "${EMACS_SOURCE_SHA}"; \
+        test "$(git -C emacs-source rev-parse HEAD)" = "${EMACS_SOURCE_SHA}"; \
+        (cd emacs-source && ./autogen.sh autoconf); \
+    else \
+        curl --fail --location \
+            "https://ftp.gnu.org/gnu/emacs/emacs-${EMACS_VERSION}.tar.xz" \
+            --output emacs.tar.xz; \
+        tar --extract --file emacs.tar.xz \
+            --strip-components 1 --directory emacs-source; \
+        rm emacs.tar.xz; \
+    fi
 
-WORKDIR /opt/emacs/emacs-${EMACS_VERSION}
+WORKDIR /opt/emacs/emacs-source
 
 RUN ./configure \
         --without-native-compilation \
@@ -42,7 +76,8 @@ RUN ./configure \
         --with-xml2 \
     && make -j "${JOBS}" \
     && make install \
-    && rm -rf "/opt/emacs/emacs-${EMACS_VERSION}"
+    && cd / \
+    && rm -rf /opt/emacs/emacs-source
 
 WORKDIR /opt
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 IMG ?= combobulate
 TAG ?= dev
 EMACS_VERSION ?= 29.4
+EMACS_SOURCE_REF ?=
+EMACS_SOURCE_SHA ?=
 JOBS ?= 4
 DOCKER_CMD ?= docker run --rm -w /opt/ $(DOCKER_ARGS) $(IMG):$(TAG)
 EMACS_BIN ?= emacs
@@ -62,9 +64,11 @@ run-tests-junit: byte-compile
 .PHONY:	docker-build
 docker-build:
 	docker build \
-		--build-arg EMACS_VERSION=$(EMACS_VERSION) \
-		--build-arg JOBS=$(JOBS) \
-		-t $(IMG):$(TAG) .
+		--build-arg EMACS_VERSION="$(EMACS_VERSION)" \
+		--build-arg EMACS_SOURCE_REF="$(EMACS_SOURCE_REF)" \
+		--build-arg EMACS_SOURCE_SHA="$(EMACS_SOURCE_SHA)" \
+		--build-arg JOBS="$(JOBS)" \
+		-t "$(IMG):$(TAG)" .
 
 .PHONY:	docker-build-tests
 docker-build-tests: docker-build

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -217,7 +217,7 @@
                           (not ,--pre-existing-session))
                  (prog1
                      (signal 'combobulate-refactor-uncommitted-changes
-                             (format "Uncommitted changes in session `%s'" ,--session))
+                             (list (format "Uncommitted changes in session `%s'" ,--session)))
                    (combobulate-refactor-delete-session ,--session))))
            (t (rollback) (signal (car err) (cdr err))))))))
 (defun combobulate-tally-nodes (nodes &optional skip-label)

--- a/tests/combobulate-test-suite.el
+++ b/tests/combobulate-test-suite.el
@@ -336,7 +336,8 @@ doesn't exist."
       (progn
         (combobulate-test-go-to-overlay number)
         (combobulate-test-execute-action action))
-    (signal 'missing-overlay (format "No overlay found for number %s" number))))
+    (signal 'missing-overlay
+            (list (format "No overlay found for number %s" number)))))
 
 (cl-defmethod combobulate-test-harness-run-and-write-test ((obj combobulate-test-harness))
   (with-slots (collection-name fixture-buffer fixture-file-name marker-number output-buffer action-body command-error)


### PR DESCRIPTION
## Summary

- add a source-backed `Emacs 31.x` CI lane that resolves `refs/heads/emacs-31` to a full commit SHA before building
- verify the fetched ref still matches that SHA, run `autogen.sh`, and include the SHA in Docker and GitHub Actions cache identity
- preserve the 29.4/30.2 tarball lanes and hardened read-only test / no-checkout reporting split
- add a sandboxed load-path smoke test and publish `ERT / Emacs 31.x` alongside the existing reports
- pass proper list-shaped custom error data, as required by Emacs 31's stricter error predicates

The matrix comments document switching to immutable `refs/tags/emacs-31.1` / `31.1` once released and adding a future `emacs-32` lane as another source-backed row.

## Local validation

- `actionlint 1.7.12 .github/workflows/ci.yml`
- `git diff --check`
- source image built from `emacs-31@48a481ac8d8d0c2436ee343b582755d51c608374`
- image reports Emacs 31.0.90 with tree-sitter and every required grammar
- load-path smoke test passes
- full JUnit suites pass 1,338/1,338 on Emacs 29.4, 30.2, and 31.0.90
- mismatched source SHA fails closed before configuration/build
- release-tarball Docker path rebuilt and verified on Emacs 29.4
