### PR TITLE
Fix autoloads to work properly

### DIFF
--- a/combobulate-setup.el
+++ b/combobulate-setup.el
@@ -505,16 +505,6 @@ modes with conflicting ideas of what type of language to use."
                 (combobulate-message
                  (substitute-command-keys "Activating Combobulate. Type \\[combobulate] to start."))))))))))
 
-;;;###autoload
-(defun combobulate-mode (&optional arg &rest _)
-  "Navigate and edit by syntactic constructs.
-
-This is a helper command that tries to activate the right
-Combobulate minor mode suitable for the current buffer."
-  (interactive "p")
-  ;; This is no longer an actual minor mode, but instead a function.
-  (combobulate-maybe-activate nil (not (null arg))))
-
 (defun combobulate-register-language (language major-modes minor-mode-fn)
   "Register a Combobulate language.
 

--- a/combobulate.el
+++ b/combobulate.el
@@ -36,59 +36,42 @@
 
 ;;; internal
 
-;;; NOTE: The autoload cookies are required so third-party package
-;;; managers like straight.el work correctly. I cannot verify that
-;;; this assertion is entirely correct, but I think straight.el does
-;;; something with autoloading that is substantially different from
-;;; what `use-package' does when you set a `:load-path'.
-
-
-;;;###autoload
+(require 'combobulate-setup)
 (require 'combobulate-rules)
-;;;###autoload
 (require 'combobulate-procedure)
-;;;###autoload
 (require 'combobulate-navigation)
-;;;###autoload
 (require 'combobulate-manipulation)
-;;;###autoload
 (require 'combobulate-envelope)
-;;;###autoload
 (require 'combobulate-display)
-;;;###autoload
 (require 'combobulate-ui)
-;;;###autoload
 (require 'combobulate-misc)
-;;;###autoload
 (require 'combobulate-query)
-;;;###autoload
 (require 'combobulate-cursor)
 ;;; end internal
 
 
 
 ;;; language support
-;;;###autoload
 (require 'combobulate-toml)
-;;;###autoload
 (require 'combobulate-html)
-;;;###autoload
 (require 'combobulate-python)
-;;;###autoload
 (require 'combobulate-js-ts)
-;;;###autoload
 (require 'combobulate-css)
-;;;###autoload
 (require 'combobulate-yaml)
-;;;###autoload
 (require 'combobulate-json)
-;;;###autoload
 (require 'combobulate-go)
-;;;###autoload
 (require 'combobulate-ocaml)
 ;;; end language support
 
+;;;###autoload
+(defun combobulate-mode (&optional arg &rest _)
+  "Navigate and edit by syntactic constructs.
+
+This is a helper command that tries to activate the right
+Combobulate minor mode suitable for the current buffer."
+  (interactive "p")
+  ;; This is no longer an actual minor mode, but instead a function.
+  (combobulate-maybe-activate nil (not (null arg))))
+
 (provide 'combobulate)
 ;;; combobulate.el ends here
-
-


### PR DESCRIPTION
Fix combobulate-mode to be properly autoloaded: it silently depends on all the other combobulate files being loaded, so it should be defined in combobulate.el which loads those files.

This removes the need for the autoloading of the entire combobulate package, so remove that.