### PR TITLE
Use official Savannah source for prerelease Emacs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
         id: emacs-source
         env:
           EMACS_SOURCE_REF: ${{ matrix.emacs-source-ref }}
-          # Established read-only mirror of the canonical Savannah repository.
-          EMACS_SOURCE_REPOSITORY: https://github.com/emacs-mirror/emacs.git
+          # Official GNU Emacs repository hosted by Savannah.
+          EMACS_SOURCE_REPOSITORY: https://git.savannah.gnu.org/git/emacs.git
         run: |
           set -euo pipefail
           cache_key="emacs-${{ matrix.emacs-version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ ENV EMACS_VERSION=${EMACS_VERSION}
 
 WORKDIR /opt/emacs
 
-# Release lanes use GNU tarballs. Prerelease lanes use the established
-# read-only Emacs mirror and supply both a named ref and its separately resolved
-# full commit SHA; consuming the SHA here also makes it part of the Docker layer
-# cache identity.
+# Release lanes use GNU tarballs. Prerelease lanes use the official Savannah
+# repository and supply both a named ref and its separately resolved full commit
+# SHA; consuming the SHA here also makes it part of the Docker layer cache
+# identity.
 RUN set -eu; \
     mkdir emacs-source; \
     if [ -n "${EMACS_SOURCE_REF}" ] || [ -n "${EMACS_SOURCE_SHA}" ]; then \
@@ -46,7 +46,7 @@ RUN set -eu; \
         printf '%s\n' "${EMACS_SOURCE_SHA}" | grep -Eq '^[0-9a-f]{40}$'; \
         git -C emacs-source init --quiet; \
         git -C emacs-source remote add origin \
-            https://github.com/emacs-mirror/emacs.git; \
+            https://git.savannah.gnu.org/git/emacs.git; \
         git -C emacs-source -c protocol.version=2 fetch \
             --depth 1 --no-tags origin "${EMACS_SOURCE_REF}"; \
         fetched_sha="$(git -C emacs-source rev-parse 'FETCH_HEAD^{commit}')"; \


### PR DESCRIPTION
## Summary
- resolve the Emacs 31.x branch from GNU Emacs's official Savannah Git repository
- fetch the source build from that same official repository
- retain named-ref/full-SHA verification, SHA-scoped caches, and all existing CI trust boundaries

## Validation
- actionlint 1.7.12
- git diff --check
- immutable Action-pin and CI security assertions
- Savannah ref resolution plus independent depth-one fetch at `48a481ac8d8d0c2436ee343b582755d51c608374`
- deliberate SHA mismatch rejected by the Docker build
- Savannah-built Emacs 31.0.90 grammar and /opt load-path smokes
- 1,338/1,338 ERT tests with zero JUnit failures or errors