### PR TITLE
Use official Savannah source for prerelease Emacs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
         id: emacs-source
         env:
           EMACS_SOURCE_REF: ${{ matrix.emacs-source-ref }}
-          # Established read-only mirror of the canonical Savannah repository.
-          EMACS_SOURCE_REPOSITORY: https://github.com/emacs-mirror/emacs.git
+          # Official GNU Emacs repository hosted by Savannah.
+          EMACS_SOURCE_REPOSITORY: https://git.savannah.gnu.org/git/emacs.git
         run: |
           set -euo pipefail
           cache_key="emacs-${{ matrix.emacs-version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ ENV EMACS_VERSION=${EMACS_VERSION}
 
 WORKDIR /opt/emacs
 
-# Release lanes use GNU tarballs. Prerelease lanes use the established
-# read-only Emacs mirror and supply both a named ref and its separately resolved
-# full commit SHA; consuming the SHA here also makes it part of the Docker layer
-# cache identity.
+# Release lanes use GNU tarballs. Prerelease lanes use the official Savannah
+# repository and supply both a named ref and its separately resolved full commit
+# SHA; consuming the SHA here also makes it part of the Docker layer cache
+# identity.
 RUN set -eu; \
     mkdir emacs-source; \
     if [ -n "${EMACS_SOURCE_REF}" ] || [ -n "${EMACS_SOURCE_SHA}" ]; then \
@@ -46,7 +46,7 @@ RUN set -eu; \
         printf '%s\n' "${EMACS_SOURCE_SHA}" | grep -Eq '^[0-9a-f]{40}$'; \
         git -C emacs-source init --quiet; \
         git -C emacs-source remote add origin \
-            https://github.com/emacs-mirror/emacs.git; \
+            https://git.savannah.gnu.org/git/emacs.git; \
         git -C emacs-source -c protocol.version=2 fetch \
             --depth 1 --no-tags origin "${EMACS_SOURCE_REF}"; \
         fetched_sha="$(git -C emacs-source rev-parse 'FETCH_HEAD^{commit}')"; \


### PR DESCRIPTION
## Summary
- resolve and fetch the Emacs 31.x branch from GNU Emacs's official Savannah Git repository
- retain named-ref/full-SHA verification, SHA-scoped caches, and the hardened test/report split
- preserve development's generated-harness and load-path/straight.el/:vc installation smoke behavior

## Validation
- actionlint 1.7.12 and git diff --check
- immutable Action-pin and CI security assertions
- Savannah-built Emacs 31.0.90 image with all 11 development grammars
- /opt and installation load-path smoke tests
- 695/695 ERT tests with zero JUnit failures or errors
- patch limited to .github/workflows/ci.yml and Dockerfile source/comment lines