### PR TITLE
Normalize development version marker

### DIFF
--- a/combobulate-css.el
+++ b/combobulate-css.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-cursor.el
+++ b/combobulate-cursor.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-debug.el
+++ b/combobulate-debug.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-display.el
+++ b/combobulate-display.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-html.el
+++ b/combobulate-html.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-js-ts.el
+++ b/combobulate-js-ts.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-misc.el
+++ b/combobulate-misc.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-navigation.el
+++ b/combobulate-navigation.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-python.el
+++ b/combobulate-python.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-query.el
+++ b/combobulate-query.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-settings.el
+++ b/combobulate-settings.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate-ui.el
+++ b/combobulate-ui.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.1
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 

--- a/combobulate.el
+++ b/combobulate.el
@@ -4,7 +4,7 @@
 
 ;; Author: Mickey Petersen <mickey at masteringemacs.org>
 ;; Package-Requires: ((emacs "29"))
-;; Version: 0.0.0-git
+;; Version: 1.0.0-git
 ;; Homepage: https://www.github.com/mickeynp/combobulate
 ;; Keywords: convenience, tools, languages
 


### PR DESCRIPTION
## Summary
- normalize top-level first-party package headers to `1.0.0-git`
- keep fixtures and vendored test dependencies untouched

## Validation
- native Emacs 30.2 package metadata parsing for all 14 marked files
- `make run-tests`: 1,338 passed, 0 unexpected
- `git diff --check`