### PR TITLE
Add Scheme support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
               (unless (treesit-available-p)
                 (error "Emacs was built without tree-sitter support"))
               (dolist (language (quote (css dockerfile go html javascript json
-                                        python toml tsx typescript yaml)))
+                                        python scheme toml tsx typescript yaml)))
                 (unless (treesit-language-available-p language)
                   (error "Missing %s grammar" language))))'
 

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,9 @@ Here is a list of the languages currently supported.
 |Python              |python-mode, python-ts-mode                                   |v0.20.4             |
 |                    |                                                              |                    |
 +--------------------+--------------------------------------------------------------+--------------------+
+|Scheme              |scheme-mode                                                   |v0.24.7-1           |
+|                    |                                                              |                    |
++--------------------+--------------------------------------------------------------+--------------------+
 |YAML                |yaml-mode, yaml-ts-mode                                       |v0.5.0              |
 |                    |                                                              |                    |
 +--------------------+--------------------------------------------------------------+--------------------+
@@ -221,6 +224,7 @@ Note that this example uses ``major-mode-remap-alist`` to turn your regular majo
                    (json . ("https://github.com/tree-sitter/tree-sitter-json" "v0.20.2"))
                    (markdown . ("https://github.com/ikatyang/tree-sitter-markdown" "v0.7.1"))
                    (python . ("https://github.com/tree-sitter/tree-sitter-python" "v0.20.4"))
+                   (scheme . ("https://github.com/6cdh/tree-sitter-scheme" "v0.24.7-1"))
                    (rust . ("https://github.com/tree-sitter/tree-sitter-rust" "v0.21.2"))
                    (toml . ("https://github.com/tree-sitter/tree-sitter-toml" "v0.5.1"))
                    (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "tsx/src"))

--- a/build/scheme-grammar.json
+++ b/build/scheme-grammar.json
@@ -1,0 +1,12639 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
+  "name": "scheme",
+  "rules": {
+    "program": {
+      "type": "REPEAT",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_token"
+      }
+    },
+    "_token": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_intertoken"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "_intertoken": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "REPEAT1",
+            "content": {
+              "type": "PATTERN",
+              "value": "[ \\r\\n\\t\\f\\v\\p{Zs}\\p{Zl}\\p{Zp}]"
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "directive"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_comment"
+        }
+      ]
+    },
+    "comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": ";.*"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "#;"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_intertoken"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_datum"
+            }
+          ]
+        }
+      ]
+    },
+    "directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#!"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^ \\r\\n\\t\\f\\v\\p{Zs}\\p{Zl}\\p{Zp}#;\"'`,\\(\\)\\{\\}\\[\\]\\\\\\|]"
+                }
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "PATTERN",
+                          "value": "[^\\|\\\\]+"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "\\\\[xX][0-9a-fA-F]+;"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "\\\\[abtnr]"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\|"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#|"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PREC",
+                "value": 100,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "block_comment"
+                }
+              },
+              {
+                "type": "PATTERN",
+                "value": ".|[\\r\\n\\u{85}\\u{2028}\\u{2029}]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": 100,
+          "content": {
+            "type": "STRING",
+            "value": "|#"
+          }
+        }
+      ]
+    },
+    "_datum": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "boolean"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "character"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "byte_vector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quote"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quasiquote"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unquote"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unquote_splicing"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "syntax"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "quasisyntax"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unsyntax"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unsyntax_splicing"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword"
+        }
+      ]
+    },
+    "boolean": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[tTfF]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[tTfF]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[tTfF]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[tT][rR][uU][eE]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[fF][aA][lL][sS][eE]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "number": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#B"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#B"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "STRING",
+                                      "value": "#"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#o"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#O"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#o"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#O"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "STRING",
+                                      "value": "#"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#D"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#D"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "STRING",
+                                      "value": "#"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eEsSfFdDlL]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eEsSfFdDlL]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eEsSfFdDlL]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eEsSfFdDlL]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "REPEAT",
+                                                    "content": {
+                                                      "type": "STRING",
+                                                      "value": "#"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eEsSfFdDlL]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eEsSfFdDlL]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eEsSfFdDlL]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eEsSfFdDlL]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eEsSfFdDlL]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#x"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#X"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#x"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#X"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "STRING",
+                                      "value": "#"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "STRING",
+                                                  "value": "#"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "STRING",
+                                          "value": "#"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "STRING",
+                                              "value": "#"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#B"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#b"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#B"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": ""
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "|"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "nan.0"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "inf.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "[+-]"
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[01]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "/"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[01]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": ""
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "|"
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "nan.0"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "inf.0"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[01]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#o"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#O"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#o"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#O"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": ""
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "|"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "nan.0"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "inf.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "[+-]"
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-7]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "/"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-7]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": ""
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "|"
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "nan.0"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "inf.0"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-7]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#D"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#d"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#D"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[eEsSfFdDlL]"
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[+-]"
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "."
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[eEsSfFdDlL]"
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[+-]"
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "."
+                                                  },
+                                                  {
+                                                    "type": "REPEAT",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[eEsSfFdDlL]"
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[+-]"
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "."
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[eEsSfFdDlL]"
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[+-]"
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "|"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "nan.0"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "inf.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "[+-]"
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "/"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "SEQ",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[eEsSfFdDlL]"
+                                                                  },
+                                                                  {
+                                                                    "type": "CHOICE",
+                                                                    "members": [
+                                                                      {
+                                                                        "type": "PATTERN",
+                                                                        "value": "[+-]"
+                                                                      },
+                                                                      {
+                                                                        "type": "BLANK"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "REPEAT1",
+                                                                    "content": {
+                                                                      "type": "PATTERN",
+                                                                      "value": "[0-9]"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "."
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "SEQ",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[eEsSfFdDlL]"
+                                                                  },
+                                                                  {
+                                                                    "type": "CHOICE",
+                                                                    "members": [
+                                                                      {
+                                                                        "type": "PATTERN",
+                                                                        "value": "[+-]"
+                                                                      },
+                                                                      {
+                                                                        "type": "BLANK"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "REPEAT1",
+                                                                    "content": {
+                                                                      "type": "PATTERN",
+                                                                      "value": "[0-9]"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          },
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "."
+                                                          },
+                                                          {
+                                                            "type": "REPEAT",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "SEQ",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[eEsSfFdDlL]"
+                                                                  },
+                                                                  {
+                                                                    "type": "CHOICE",
+                                                                    "members": [
+                                                                      {
+                                                                        "type": "PATTERN",
+                                                                        "value": "[+-]"
+                                                                      },
+                                                                      {
+                                                                        "type": "BLANK"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "REPEAT1",
+                                                                    "content": {
+                                                                      "type": "PATTERN",
+                                                                      "value": "[0-9]"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          },
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "."
+                                                          },
+                                                          {
+                                                            "type": "CHOICE",
+                                                            "members": [
+                                                              {
+                                                                "type": "SEQ",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[eEsSfFdDlL]"
+                                                                  },
+                                                                  {
+                                                                    "type": "CHOICE",
+                                                                    "members": [
+                                                                      {
+                                                                        "type": "PATTERN",
+                                                                        "value": "[+-]"
+                                                                      },
+                                                                      {
+                                                                        "type": "BLANK"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "REPEAT1",
+                                                                    "content": {
+                                                                      "type": "PATTERN",
+                                                                      "value": "[0-9]"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "BLANK"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "|"
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "nan.0"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "inf.0"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "REPEAT",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      },
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "."
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "SEQ",
+                                                            "members": [
+                                                              {
+                                                                "type": "PATTERN",
+                                                                "value": "[eEsSfFdDlL]"
+                                                              },
+                                                              {
+                                                                "type": "CHOICE",
+                                                                "members": [
+                                                                  {
+                                                                    "type": "PATTERN",
+                                                                    "value": "[+-]"
+                                                                  },
+                                                                  {
+                                                                    "type": "BLANK"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": "REPEAT1",
+                                                                "content": {
+                                                                  "type": "PATTERN",
+                                                                  "value": "[0-9]"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#x"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#X"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#i"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#e"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#I"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#E"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "#x"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#X"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": ""
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "|"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "nan.0"
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "inf.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "[+-]"
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9a-fA-F]"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": "/"
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9a-fA-F]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "STRING",
+                                                    "value": ""
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "SEQ",
+                                                        "members": [
+                                                          {
+                                                            "type": "STRING",
+                                                            "value": "|"
+                                                          },
+                                                          {
+                                                            "type": "REPEAT1",
+                                                            "content": {
+                                                              "type": "PATTERN",
+                                                              "value": "[0-9]"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "nan.0"
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "inf.0"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "/"
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9a-fA-F]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": ""
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "STRING",
+                                                        "value": "|"
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "nan.0"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "inf.0"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "#[bB]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "#[bB]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[01]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[01]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[01]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[01]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[01]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "#[oO]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "#[oO]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-7]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-7]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-7]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-7]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-7]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[dD]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[dD]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eE]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eE]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "."
+                                          },
+                                          {
+                                            "type": "REPEAT",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "CHOICE",
+                                            "members": [
+                                              {
+                                                "type": "SEQ",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[eE]"
+                                                  },
+                                                  {
+                                                    "type": "CHOICE",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[+-]"
+                                                      },
+                                                      {
+                                                        "type": "BLANK"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "REPEAT1",
+                                                    "content": {
+                                                      "type": "PATTERN",
+                                                      "value": "[0-9]"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "BLANK"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-9]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "STRING",
+                                                "value": "."
+                                              },
+                                              {
+                                                "type": "REPEAT",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "SEQ",
+                                                    "members": [
+                                                      {
+                                                        "type": "PATTERN",
+                                                        "value": "[eE]"
+                                                      },
+                                                      {
+                                                        "type": "CHOICE",
+                                                        "members": [
+                                                          {
+                                                            "type": "PATTERN",
+                                                            "value": "[+-]"
+                                                          },
+                                                          {
+                                                            "type": "BLANK"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "REPEAT1",
+                                                        "content": {
+                                                          "type": "PATTERN",
+                                                          "value": "[0-9]"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-9]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "."
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9]"
+                                        }
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "[eE]"
+                                              },
+                                              {
+                                                "type": "CHOICE",
+                                                "members": [
+                                                  {
+                                                    "type": "PATTERN",
+                                                    "value": "[+-]"
+                                                  },
+                                                  {
+                                                    "type": "BLANK"
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "REPEAT1",
+                                                "content": {
+                                                  "type": "PATTERN",
+                                                  "value": "[0-9]"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "BLANK"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "#[xX]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "#[ieIE]"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "#[xX]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-]"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  },
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "/"
+                                      },
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "@"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-9a-fA-F]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[+-]"
+                                      },
+                                      {
+                                        "type": "BLANK"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "REPEAT1",
+                                        "content": {
+                                          "type": "PATTERN",
+                                          "value": "[0-9a-fA-F]"
+                                        }
+                                      },
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          },
+                                          {
+                                            "type": "STRING",
+                                            "value": "/"
+                                          },
+                                          {
+                                            "type": "REPEAT1",
+                                            "content": {
+                                              "type": "PATTERN",
+                                              "value": "[0-9a-fA-F]"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": ""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][iI][nN][fF]\\.0"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[+-][nN][aA][nN]\\.0"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "REPEAT1",
+                                "content": {
+                                  "type": "PATTERN",
+                                  "value": "[0-9a-fA-F]"
+                                }
+                              },
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "[0-9a-fA-F]"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][iI][nN][fF]\\.0"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[+-][nN][aA][nN]\\.0"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[+-]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "i"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "character": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[sS][pP][aA][cC][eE]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[nN][eE][wW][lL][iI][nN][eE]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": ".|[\\r\\n\\u{85}\\u{2028}\\u{2029}]"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "nul"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "alarm"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "backspace"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tab"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "linefeed"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "newline"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "vtab"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "page"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "return"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "esc"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "space"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "delete"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "x[0-9a-fA-F]+"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "u[0-9a-fA-F]+"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": ".|[\\r\\n\\u{85}\\u{2028}\\u{2029}]"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "alarm"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "backspace"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "delete"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "escape"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "newline"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "null"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "return"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "space"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "tab"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[xX][0-9a-fA-F]+"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": ".|[\\r\\n\\u{85}\\u{2028}\\u{2029}]"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "bel"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "ls"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "nel"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "rubout"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "vt"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\""
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "escape_sequence"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^\"\\\\]+"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
+    },
+    "escape_sequence": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\\""
+              },
+              {
+                "type": "STRING",
+                "value": "\\\\"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[abtnvfr\"\\\\]"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "x[0-9a-fA-F]+;"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\t\\p{Zs}]"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\n\\r\\u{2028}\\u{0085}]|(\\r\\n)|(\\r\\u{0085})"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\t\\p{Zs}]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "PATTERN",
+                    "value": "[abtnr\"\\\\]"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[\\t\\p{Zs}]"
+                        }
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\n\\r\\u{2028}\\u{0085}]|(\\r\\n)|(\\r\\u{0085})"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "PATTERN",
+                          "value": "[\\t\\p{Zs}]"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[xX][0-9a-fA-F]+;"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "PATTERN",
+            "value": "\\\\."
+          }
+        ]
+      }
+    },
+    "symbol": {
+      "type": "TOKEN",
+      "content": {
+        "type": "TOKEN",
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "PATTERN",
+                "value": "[^ \\r\\n\\t\\f\\v\\p{Zs}\\p{Zl}\\p{Zp}#;\"'`,\\(\\)\\{\\}\\[\\]\\\\\\|]"
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "|"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\|\\\\]+"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "\\\\[xX][0-9a-fA-F]+;"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "\\\\[abtnr]"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "\\|"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "|"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "keyword": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "#:"
+          },
+          {
+            "type": "TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^ \\r\\n\\t\\f\\v\\p{Zs}\\p{Zl}\\p{Zp}#;\"'`,\\(\\)\\{\\}\\[\\]\\\\\\|]"
+                  }
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "|"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\|\\\\]+"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "\\\\[xX][0-9a-fA-F]+;"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "\\\\[abtnr]"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\\|"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "|"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "list": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_token"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_token"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_token"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        }
+      ]
+    },
+    "quote": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "quasiquote": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "`"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "syntax": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#'"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "quasisyntax": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#`"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "unquote": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "unquote_splicing": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ",@"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "unsyntax": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#,"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "unsyntax_splicing": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#,@"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intertoken"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_datum"
+        }
+      ]
+    },
+    "vector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#("
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_token"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "byte_vector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#vu8("
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_token"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    }
+  },
+  "extras": [],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [],
+  "inline": [],
+  "supertypes": []
+}

--- a/build/scheme-nodes.json
+++ b/build/scheme-nodes.json
@@ -1,0 +1,1347 @@
+[
+  {
+    "type": "block_comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "byte_vector",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "program",
+    "named": true,
+    "root": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "quasiquote",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "quasisyntax",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "quote",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "syntax",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unquote",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unquote_splicing",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unsyntax",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unsyntax_splicing",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vector",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "block_comment",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "byte_vector",
+          "named": true
+        },
+        {
+          "type": "character",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "directive",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "quasisyntax",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "syntax",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splicing",
+          "named": true
+        },
+        {
+          "type": "unsyntax",
+          "named": true
+        },
+        {
+          "type": "unsyntax_splicing",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "#!",
+    "named": false
+  },
+  {
+    "type": "#'",
+    "named": false
+  },
+  {
+    "type": "#(",
+    "named": false
+  },
+  {
+    "type": "#,",
+    "named": false
+  },
+  {
+    "type": "#,@",
+    "named": false
+  },
+  {
+    "type": "#;",
+    "named": false
+  },
+  {
+    "type": "#`",
+    "named": false
+  },
+  {
+    "type": "#vu8(",
+    "named": false
+  },
+  {
+    "type": "#|",
+    "named": false
+  },
+  {
+    "type": "'",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": ",@",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "`",
+    "named": false
+  },
+  {
+    "type": "boolean",
+    "named": true
+  },
+  {
+    "type": "character",
+    "named": true
+  },
+  {
+    "type": "escape_sequence",
+    "named": true
+  },
+  {
+    "type": "keyword",
+    "named": true
+  },
+  {
+    "type": "number",
+    "named": true
+  },
+  {
+    "type": "symbol",
+    "named": true
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "|#",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]

--- a/build/sources.ini
+++ b/build/sources.ini
@@ -48,3 +48,7 @@ grammar = https://raw.githubusercontent.com/tree-sitter/tree-sitter-toml/v0.5.1/
 [json]
 nodes = https://raw.githubusercontent.com/tree-sitter/tree-sitter-json/v0.20.2/src/node-types.json
 grammar = https://raw.githubusercontent.com/tree-sitter/tree-sitter-json/v0.20.2/src/grammar.json
+
+[scheme]
+nodes = https://raw.githubusercontent.com/6cdh/tree-sitter-scheme/v0.24.7-1/src/node-types.json
+grammar = https://raw.githubusercontent.com/6cdh/tree-sitter-scheme/v0.24.7-1/src/grammar.json

--- a/combobulate-manipulation.el
+++ b/combobulate-manipulation.el
@@ -1136,12 +1136,17 @@ Uses `procedures-defun' to determine what a
 defun is.  Repeat calls expands the scope."
   (interactive "p")
   (with-argument-repetition arg
-    (with-navigation-nodes (:procedures (combobulate-read procedures-defun) :skip-prefix t)
-      (unless (combobulate-mark-node-at-point nil t)
+    (with-navigation-nodes (:procedures (combobulate-read procedures-defun)
+                            :skip-prefix t)
+      (when (and mark-active (> (point) (mark)))
+        (exchange-point-and-mark))
+      (if-let* ((node (combobulate-nav-get-defun nil t)))
+          (progn
+            (combobulate--mark-node node nil t)
+            (combobulate--flash-node node)
+            node)
         (if (< arg 0)
             (combobulate-navigate-beginning-of-defun)
-          (when (and mark-active (> (mark) (point)))
-            (exchange-point-and-mark))
           (combobulate-navigate-end-of-defun))))))
 
 (defun combobulate--partition-by-position (self-node query-nodes )

--- a/combobulate-navigation.el
+++ b/combobulate-navigation.el
@@ -36,6 +36,8 @@
 
 (declare-function combobulate-production-rules-get-rules "combobulate-procedure")
 (declare-function combobulate-production-rules-get-inverted "combobulate-procedure")
+(declare-function combobulate-procedure-apply-activation-nodes
+  "combobulate-procedure")
 (declare-function combobulate-procedure-start-matches "combobulate-procedure")
 (declare-function combobulate-procedure-collect-activation-nodes "combobulate-procedure")
 
@@ -861,20 +863,62 @@ NODE is found or all depths have been searched."
           (throw 'done subtree))
         (cl-incf offset)))))
 
+(defun combobulate-nav-defun-node-p (node)
+  "Return non-nil when NODE satisfies a defun activation rule.
+
+Defun identity is determined by the activation rules in
+`combobulate-default-procedures'.  Selectors are intentionally not
+considered: they describe nodes selected after activation, not the node
+that constitutes the defun itself."
+  (when combobulate-default-procedures
+    (save-excursion
+      (goto-char (combobulate-node-start node))
+      (seq-some
+       (lambda (procedure)
+         (when-let* ((activation-nodes
+                     (plist-get procedure :activation-nodes)))
+           (combobulate-procedure-apply-activation-nodes
+            activation-nodes node)))
+       combobulate-default-procedures))))
+
+(defun combobulate-nav-get-defun (&optional node skip-region)
+  "Return the innermost defun containing NODE or point.
+
+If SKIP-REGION is non-nil, ignore defuns contained in the active
+region."
+  (when (and combobulate-default-procedures
+             (setq node (or node (combobulate-node-at-point))))
+    (seq-find
+     (lambda (candidate)
+       (and (combobulate-nav-defun-node-p candidate)
+            (or (not skip-region)
+                (not (combobulate-node-in-region-p candidate)))))
+     (cons node (combobulate-get-parents node)))))
+
 (defun combobulate-nav-to-defun (direction &optional node)
   "Navigate to a defun in DIRECTION, possibly from NODE.
 
 DIRECTION must be `forward' or `backward'."
-  (when-let* ((current-node (or node
+  (when-let* ((current-node (or (combobulate-nav-get-defun node)
+                                node
                                 (combobulate--get-nearest-navigable-node)
                                 (combobulate-node-at-point)))
               (min-depth most-positive-fixnum)
-              (tree (save-excursion
-                      (combobulate-move-to-node current-node (eq direction 'backward))
-                      (combobulate-build-sparse-tree direction combobulate-navigable-nodes
-                                                     (if (eq direction 'backward)
-                                                         #'combobulate-node-before-point-p
-                                                       #'combobulate-node-on-or-after-point-p)))))
+              (tree
+               (save-excursion
+                 (combobulate-move-to-node current-node
+                                           (eq direction 'backward))
+                 (combobulate-build-sparse-tree
+                  direction combobulate-navigable-nodes
+                  (lambda (candidate)
+                    (and
+                     (funcall
+                      (if (eq direction 'backward)
+                          #'combobulate-node-before-point-p
+                        #'combobulate-node-on-or-after-point-p)
+                      candidate)
+                     (or (null combobulate-default-procedures)
+                         (combobulate-nav-defun-node-p candidate))))))))
     (let ((valid-nodes)
           (current-node-depth
            ;; determine the smallest depth in the tree and also the

--- a/combobulate-rules.el
+++ b/combobulate-rules.el
@@ -2316,9 +2316,72 @@
 )
 ;; END All supertypes in json
 
+;; START Production rules for scheme
+(defconst combobulate-rules-scheme 
+ '(("block_comment" (:*unnamed* ("block_comment"))) 
+ ("boolean" (:*unnamed* nil)) 
+ ("byte_vector" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("character" (:*unnamed* nil)) 
+ ("comment" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("directive" (:*unnamed* ("block_comment" "comment" "directive"))) 
+ ("escape_sequence" (:*unnamed* nil)) 
+ ("keyword" (:*unnamed* nil)) 
+ ("list" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("number" (:*unnamed* nil)) 
+ ("program" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("quasiquote" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("quasisyntax" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("quote" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("string" (:*unnamed* ("escape_sequence"))) 
+ ("symbol" (:*unnamed* nil)) 
+ ("syntax" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("unquote" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("unquote_splicing" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("unsyntax" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("unsyntax_splicing" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+ ("vector" (:*unnamed* ("list" "block_comment" "byte_vector" "directive" "unsyntax_splicing" "comment" "quote" "unquote_splicing" "quasiquote" "character" "string" "syntax" "boolean" "number" "vector" "unquote" "keyword" "symbol" "unsyntax" "quasisyntax"))) 
+))
+;; END Production rules for scheme
+;; START Inverse production rules for scheme
+(defconst combobulate-rules-scheme-inverse 
+ '(("block_comment" ("list" "block_comment" "byte_vector" "unsyntax" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "directive" "quasisyntax" "program" "syntax"))
+   ("boolean" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("byte_vector" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("character" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("comment" ("list" "byte_vector" "unsyntax" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "directive" "quasisyntax" "program" "syntax"))
+   ("directive" ("list" "byte_vector" "unsyntax" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "directive" "quasisyntax" "program" "syntax"))
+   ("escape_sequence" ("string"))
+   ("keyword" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("list" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("number" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("quasiquote" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("quasisyntax" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("quote" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("string" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("symbol" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("syntax" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("unquote" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("unquote_splicing" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("unsyntax" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("unsyntax_splicing" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+   ("vector" ("list" "byte_vector" "unsyntax_splicing" "vector" "comment" "unquote" "quote" "unquote_splicing" "quasiquote" "unsyntax" "quasisyntax" "program" "syntax"))
+  ) 
+)
+;; END Inverse production rules for scheme
+;; START All node types in scheme
+(defconst combobulate-rules-scheme-types 
+ '("block_comment" "boolean" "byte_vector" "character" "comment" "directive" "escape_sequence" "keyword" "list" "number" "program" "quasiquote" "quasisyntax" "quote" "string" "symbol" "syntax" "unquote" "unquote_splicing" "unsyntax" "unsyntax_splicing" "vector") 
+)
+;; END All node types in scheme
+;; START All supertypes in scheme
+(defconst combobulate-rules-scheme-supertypes 
+ nil 
+)
+;; END All supertypes in scheme
+
 ;; START Auto-generated list of all languages
 (defconst combobulate-rules-languages 
- '(c css dockerfile go html javascript json python toml tsx typescript yaml) 
+ '(c css dockerfile go html javascript json python scheme toml tsx typescript yaml) 
  "A list of all the languages that have production rules.")
 ;; END Auto-generated list of all languages
 (defconst combobulate-rules-alist 
@@ -2330,6 +2393,7 @@
  (javascript ,combobulate-rules-javascript)
  (json ,combobulate-rules-json)
  (python ,combobulate-rules-python)
+ (scheme ,combobulate-rules-scheme)
  (toml ,combobulate-rules-toml)
  (tsx ,combobulate-rules-tsx)
  (typescript ,combobulate-rules-typescript)
@@ -2345,6 +2409,7 @@
  (javascript ,combobulate-rules-javascript-inverse)
  (json ,combobulate-rules-json-inverse)
  (python ,combobulate-rules-python-inverse)
+ (scheme ,combobulate-rules-scheme-inverse)
  (toml ,combobulate-rules-toml-inverse)
  (tsx ,combobulate-rules-tsx-inverse)
  (typescript ,combobulate-rules-typescript-inverse)
@@ -2360,6 +2425,7 @@
  (javascript ,combobulate-rules-javascript-types)
  (json ,combobulate-rules-json-types)
  (python ,combobulate-rules-python-types)
+ (scheme ,combobulate-rules-scheme-types)
  (toml ,combobulate-rules-toml-types)
  (tsx ,combobulate-rules-tsx-types)
  (typescript ,combobulate-rules-typescript-types)
@@ -2375,6 +2441,7 @@
  (javascript ,combobulate-rules-javascript-supertypes)
  (json ,combobulate-rules-json-supertypes)
  (python ,combobulate-rules-python-supertypes)
+ (scheme ,combobulate-rules-scheme-supertypes)
  (toml ,combobulate-rules-toml-supertypes)
  (tsx ,combobulate-rules-tsx-supertypes)
  (typescript ,combobulate-rules-typescript-supertypes)

--- a/combobulate-scheme.el
+++ b/combobulate-scheme.el
@@ -1,0 +1,95 @@
+;;; combobulate-scheme.el --- Scheme support  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  coopi
+
+;; Author: coopi <coldsideofyourpillow@disroot.org>
+;; Keywords: convenience, languages, scheme
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Structural editing and navigation for Scheme using tree-sitter-scheme.
+
+;;; Code:
+
+(require 'combobulate-navigation)
+(require 'combobulate-rules)
+(require 'combobulate-setup)
+
+(eval-and-compile
+  (defconst combobulate-scheme--datum-rules
+    '((exclude (rule "program")
+               "block_comment" "comment" "directive"))
+    "Rules matching Scheme datums.")
+
+  (defconst combobulate-scheme--compound-datum-rules
+    '((exclude (irule "symbol")
+               "comment" "program"))
+    "Rules matching Scheme datums that can contain other datums.")
+
+  (defconst combobulate-scheme-definitions
+    `((context-nodes
+       '("boolean" "character" "keyword" "number" "string" "symbol"))
+      (envelope-default-list
+       '((:description
+          "( ... )"
+          :key "("
+          :extra-key "M-("
+          :mark-node t
+          :split-node t
+          :nodes ((:activation-nodes
+                   ((:nodes ,combobulate-scheme--datum-rules))))
+          :name "wrap-parentheses"
+          :template (@ "(" r ")"))))
+      (plausible-separators nil)
+      (procedure-discard-rules '("block_comment" "comment" "directive"))
+      (procedures-default
+       '((:activation-nodes
+          ((:nodes ,combobulate-scheme--datum-rules)))))
+      (procedures-defun
+       '((:activation-nodes
+          ((:nodes ,combobulate-scheme--datum-rules
+            :has-parent ("program"))))))
+      (procedures-hierarchy
+       '((:activation-nodes
+          ((:nodes ,combobulate-scheme--compound-datum-rules))
+          :selector
+          (:choose node
+           :match-children
+           (:match-rules ,combobulate-scheme--datum-rules)))))
+      (procedures-sexp
+       '((:activation-nodes
+          ((:nodes ,combobulate-scheme--datum-rules)))))
+      (procedures-sibling
+       '((:activation-nodes
+          ((:nodes ,combobulate-scheme--datum-rules
+            :has-parent ("program" "list" "vector" "byte_vector")))
+          :selector
+          (:choose parent
+           :match-children
+           (:match-rules ,combobulate-scheme--datum-rules))))))
+    "Combobulate procedure definitions for Scheme."))
+
+(define-combobulate-language
+ :name scheme
+ :language scheme
+ :major-modes (scheme-mode)
+ :custom combobulate-scheme-definitions
+ :setup-fn combobulate-scheme-setup)
+
+(defun combobulate-scheme-setup (_))
+
+(provide 'combobulate-scheme)
+;;; combobulate-scheme.el ends here

--- a/combobulate.el
+++ b/combobulate.el
@@ -67,6 +67,7 @@
 (require 'combobulate-yaml)
 (require 'combobulate-json)
 (require 'combobulate-go)
+(require 'combobulate-scheme)
 ;;; end language support
 
 

--- a/tests/.ts-setup.el
+++ b/tests/.ts-setup.el
@@ -8,6 +8,7 @@
          (json . ("https://github.com/tree-sitter/tree-sitter-json" "v0.20.2"))
          (go . ("https://github.com/tree-sitter/tree-sitter-go" "v0.20.0"))
          (python . ("https://github.com/tree-sitter/tree-sitter-python" "v0.20.4"))
+         (scheme . ("https://github.com/6cdh/tree-sitter-scheme" "v0.24.7-1"))
          (toml . ("https://github.com/tree-sitter/tree-sitter-toml" "v0.5.1"))
          (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "tsx/src"))
          (typescript . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "typescript/src"))

--- a/tests/combobulate-test-suite.el
+++ b/tests/combobulate-test-suite.el
@@ -426,11 +426,16 @@ doesn't exist."
   (with-current-buffer (oref obj output-buffer)
     (let* ((numbers)
            (fixture-buf (find-file-noselect fixture-file-name))
-           (fixture-language) (fixture-major-mode) (lang))
+           (fixture-language) (fixture-major-mode))
       (with-current-buffer fixture-buf
-        (setq lang (car (combobulate-parser-list)))
-        (cl-assert (not (null lang)) nil "No language found in `%s' (major mode: `%s')" fixture-file-name major-mode)
-        (setq fixture-language (combobulate-parser-language lang))
+        (let ((parser (car (combobulate-parser-list))))
+          (setq fixture-language
+                (if parser
+                    (combobulate-parser-language parser)
+                  (combobulate-primary-language t))))
+        (cl-assert (not (null fixture-language)) nil
+                   "No language found in `%s' (major mode: `%s')"
+                   fixture-file-name major-mode)
         (setf fixture-major-mode major-mode)
         (setq numbers (seq-sort #'< (mapcar (lambda (ov) (overlay-get ov 'combobulate-test-number))
                                             (combobulate--with-test-overlays)))))

--- a/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa aaa (bbb) 'ccc #(ddd))

--- a/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa (bbb) (bbb) 'ccc #(ddd))

--- a/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa (bbb) 'ccc 'ccc #(ddd))

--- a/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@4~after].scm
+++ b/tests/fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@4~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa (bbb) 'ccc #(ddd) #(ddd))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{bbb aaa ccc}

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{aaa ccc bbb}

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{aaa bbb ccc}

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[bbb aaa ccc]

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[aaa ccc bbb]

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[aaa bbb ccc]

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(22 11 33)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 33 22)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 22 33)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@10~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@10~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) symbol "text" #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@11~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@11~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" #'(syntax) symbol ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@12~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@12~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol ,unquote #'(syntax) ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@13~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@13~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,@splice ,unquote #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@14~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@14~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote #,unsyntax ,@splice #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@15~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@15~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,@unsplice #,unsyntax #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@16~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@16~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #(vector) #,@unsplice)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@17~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@17~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#vu8(1 2) #t #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #\a #vu8(1 2) #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #:keyword #\a (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@4~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@4~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a (nested) #:keyword 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@5~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@5~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword 42 (nested) `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@6~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@6~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) `(quasi) 42 #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@7~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@7~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 #`(quasisyntax) `(quasi) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@8~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@8~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) '(quoted) #`(quasisyntax) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@9~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-datums.scm[@9~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) "text" '(quoted) symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(bbb aaa ccc)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa ccc bbb)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa bbb ccc)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@1~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+(beta gamma)
+alpha
+#(delta epsilon)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@2~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+#(delta epsilon)
+(beta gamma)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@3~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+(beta gamma)
+'zeta
+#(delta epsilon)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@4~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-program.scm[@4~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+(beta gamma)
+#(delta epsilon)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(bbb aaa ccc)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(aaa ccc bbb)

--- a/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-down/scheme-vector.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(aaa bbb ccc)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{aaa bbb ccc}

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{bbb aaa ccc}

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{aaa ccc bbb}

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[aaa bbb ccc]

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[bbb aaa ccc]

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[aaa ccc bbb]

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 22 33)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(22 11 33)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 33 22)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@10~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@10~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) "text" '(quoted) symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@11~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@11~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) symbol "text" #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@12~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@12~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" #'(syntax) symbol ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@13~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@13~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol ,unquote #'(syntax) ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@14~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@14~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,@splice ,unquote #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@15~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@15~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote #,unsyntax ,@splice #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@16~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@16~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,@unsplice #,unsyntax #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@17~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@17~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #(vector) #,@unsplice)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#vu8(1 2) #t #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #\a #vu8(1 2) #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@4~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@4~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #:keyword #\a (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@5~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@5~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a (nested) #:keyword 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@6~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@6~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword 42 (nested) `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@7~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@7~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) `(quasi) 42 #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@8~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@8~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 #`(quasisyntax) `(quasi) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@9~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-datums.scm[@9~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) '(quoted) #`(quasisyntax) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa bbb ccc)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(bbb aaa ccc)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-list.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa ccc bbb)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@1~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+(beta gamma)
+#(delta epsilon)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@2~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+(beta gamma)
+alpha
+#(delta epsilon)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@3~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+#(delta epsilon)
+(beta gamma)
+'zeta

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@4~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-program.scm[@4~after].scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+(beta gamma)
+'zeta
+#(delta epsilon)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(aaa bbb ccc)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@2~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@2~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(bbb aaa ccc)

--- a/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@3~after].scm
+++ b/tests/fixture-deltas/combobulate-drag-up/scheme-vector.scm[@3~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(aaa ccc bbb)

--- a/tests/fixture-deltas/combobulate-kill-dwim/scheme-datums.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-kill-dwim/scheme-datums.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+()

--- a/tests/fixture-deltas/combobulate-splice-self-offset-1/choice-1-scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-splice-self-offset-1/choice-1-scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+bbb

--- a/tests/fixture-deltas/combobulate-splice-self/choice-0-scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-splice-self/choice-0-scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer bbb tail)

--- a/tests/fixture-deltas/combobulate-splice-up/choice-0-scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-splice-up/choice-0-scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer bbb ccc tail)

--- a/tests/fixture-deltas/combobulate-splice-up/choice-1-scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-splice-up/choice-1-scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer bbb ccc tail)

--- a/tests/fixture-deltas/combobulate-splice-up/scheme-list.scm[@1~after].scm
+++ b/tests/fixture-deltas/combobulate-splice-up/scheme-list.scm[@1~after].scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer bbb ccc tail)

--- a/tests/fixtures/clone/scheme-datums.scm
+++ b/tests/fixtures/clone/scheme-datums.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa (bbb) 'ccc #(ddd))

--- a/tests/fixtures/down/scheme-byte-vector.scm
+++ b/tests/fixtures/down/scheme-byte-vector.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 121) (2 outline 126)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 22)

--- a/tests/fixtures/down/scheme-list-delimiters.scm
+++ b/tests/fixtures/down/scheme-list-delimiters.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 137) (2 outline 138) (3 outline 139)); eval: (combobulate-test-fixture-mode t); -*-
+[{leaf}]

--- a/tests/fixtures/down/scheme-list.scm
+++ b/tests/fixtures/down/scheme-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 154) (3 outline 155) (4 outline 156)); eval: (combobulate-test-fixture-mode t); -*-
+(((leaf)))

--- a/tests/fixtures/down/scheme-quasiquote-splicing.scm
+++ b/tests/fixtures/down/scheme-quasiquote-splicing.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 154) (3 outline 155) (4 outline 157)); eval: (combobulate-test-fixture-mode t); -*-
+`(,@leaf)

--- a/tests/fixtures/down/scheme-quasiquote-unquote.scm
+++ b/tests/fixtures/down/scheme-quasiquote-unquote.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 154) (3 outline 155) (4 outline 156)); eval: (combobulate-test-fixture-mode t); -*-
+`(,leaf)

--- a/tests/fixtures/down/scheme-quasisyntax-splicing.scm
+++ b/tests/fixtures/down/scheme-quasisyntax-splicing.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 155) (3 outline 156) (4 outline 159)); eval: (combobulate-test-fixture-mode t); -*-
+#`(#,@leaf)

--- a/tests/fixtures/down/scheme-quasisyntax-unsyntax.scm
+++ b/tests/fixtures/down/scheme-quasisyntax-unsyntax.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 155) (3 outline 156) (4 outline 158)); eval: (combobulate-test-fixture-mode t); -*-
+#`(#,leaf)

--- a/tests/fixtures/down/scheme-quote.scm
+++ b/tests/fixtures/down/scheme-quote.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 137) (2 outline 138) (3 outline 139)); eval: (combobulate-test-fixture-mode t); -*-
+''leaf

--- a/tests/fixtures/down/scheme-syntax.scm
+++ b/tests/fixtures/down/scheme-syntax.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 137) (2 outline 139) (3 outline 141)); eval: (combobulate-test-fixture-mode t); -*-
+#'#'leaf

--- a/tests/fixtures/down/scheme-vector.scm
+++ b/tests/fixtures/down/scheme-vector.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 137) (2 outline 139) (3 outline 141)); eval: (combobulate-test-fixture-mode t); -*-
+#(#(leaf))

--- a/tests/fixtures/kill-node/scheme-datums.scm
+++ b/tests/fixtures/kill-node/scheme-datums.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 154) (2 outline 158) (3 outline 164) (4 outline 169)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa (bbb) 'ccc #(ddd))

--- a/tests/fixtures/sibling/scheme-brace-list.scm
+++ b/tests/fixtures/sibling/scheme-brace-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+{aaa bbb ccc}

--- a/tests/fixtures/sibling/scheme-bracket-list.scm
+++ b/tests/fixtures/sibling/scheme-bracket-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+[aaa bbb ccc]

--- a/tests/fixtures/sibling/scheme-byte-vector.scm
+++ b/tests/fixtures/sibling/scheme-byte-vector.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 142) (2 outline 145) (3 outline 148)); eval: (combobulate-test-fixture-mode t); -*-
+#vu8(11 22 33)

--- a/tests/fixtures/sibling/scheme-datums.scm
+++ b/tests/fixtures/sibling/scheme-datums.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 370) (2 outline 373) (3 outline 383) (4 outline 387) (5 outline 397) (6 outline 406) (7 outline 409) (8 outline 418) (9 outline 434) (10 outline 444) (11 outline 451) (12 outline 458) (13 outline 469) (14 outline 478) (15 outline 487) (16 outline 498) (17 outline 510)); eval: (combobulate-test-fixture-mode t); -*-
+(#t #vu8(1 2) #\a #:keyword (nested) 42 `(quasi) #`(quasisyntax) '(quoted) "text" symbol #'(syntax) ,unquote ,@splice #,unsyntax #,@unsplice #(vector))

--- a/tests/fixtures/sibling/scheme-list.scm
+++ b/tests/fixtures/sibling/scheme-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 138) (2 outline 142) (3 outline 146)); eval: (combobulate-test-fixture-mode t); -*-
+(aaa bbb ccc)

--- a/tests/fixtures/sibling/scheme-program.scm
+++ b/tests/fixtures/sibling/scheme-program.scm
@@ -1,0 +1,5 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 153) (2 outline 159) (3 outline 172) (4 outline 189)); eval: (combobulate-test-fixture-mode t); -*-
+alpha
+(beta gamma)
+#(delta epsilon)
+'zeta

--- a/tests/fixtures/sibling/scheme-vector.scm
+++ b/tests/fixtures/sibling/scheme-vector.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 139) (2 outline 143) (3 outline 147)); eval: (combobulate-test-fixture-mode t); -*-
+#(aaa bbb ccc)

--- a/tests/fixtures/splice/choice-0-scheme-list.scm
+++ b/tests/fixtures/splice/choice-0-scheme-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer (inner aaa bbb ccc) tail)

--- a/tests/fixtures/splice/choice-1-scheme-list.scm
+++ b/tests/fixtures/splice/choice-1-scheme-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer (inner aaa bbb ccc) tail)

--- a/tests/fixtures/splice/scheme-list.scm
+++ b/tests/fixtures/splice/scheme-list.scm
@@ -1,0 +1,2 @@
+;; -*- combobulate-test-point-overlays: ((1 outline 123)); eval: (combobulate-test-fixture-mode t); -*-
+(outer (inner aaa bbb ccc) tail)

--- a/tests/test-combobulate-clone-dwim.gen.el
+++ b/tests/test-combobulate-clone-dwim.gen.el
@@ -424,6 +424,57 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-clone-dwim/python-list.py[@5~after].py")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-clone-dwim--scheme-datums-1 ()
+ "Test `combobulate' with `fixtures/clone/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/clone/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-clone-dwim)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0))
+		 (combobulate-clone-node-dwim))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-clone-dwim--scheme-datums-2 ()
+ "Test `combobulate' with `fixtures/clone/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/clone/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-clone-dwim)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0))
+		 (combobulate-clone-node-dwim))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-clone-dwim--scheme-datums-3 ()
+ "Test `combobulate' with `fixtures/clone/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/clone/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-clone-dwim)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0))
+		 (combobulate-clone-node-dwim))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-clone-dwim--scheme-datums-4 ()
+ "Test `combobulate' with `fixtures/clone/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/clone/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-clone-dwim)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0))
+		 (combobulate-clone-node-dwim))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-clone-dwim/scheme-datums.scm[@4~after].scm")))
 (ert-deftest combobulate-test-yaml-combobulate-clone-dwim--yaml-block-mapping-pairs-1 ()
  "Test `combobulate' with `fixtures/clone/yaml-block-mapping-pairs.yaml' in `yaml-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-drag-down.gen.el
+++ b/tests/test-combobulate-drag-down.gen.el
@@ -1939,6 +1939,379 @@
 		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/python-tuple.py[@5~after].py")))))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-brace-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-brace-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-brace-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 3)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-brace-list.scm[@3~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-bracket-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-bracket-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-bracket-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 3)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-bracket-list.scm[@3~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-byte-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-byte-vector-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-byte-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 3)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-byte-vector.scm[@3~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-4 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@4~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-5 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 5)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@5~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-6 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 6)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@6~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-7 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 7)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@7~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-8 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 8)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@8~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-9 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 9)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@9~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-10 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 10)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@10~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-11 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 11)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@11~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-12 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 12)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@12~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-13 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 13)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@13~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-14 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 14)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@14~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-15 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 15)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@15~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-16 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 16)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@16~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-datums-17 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 17)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-datums.scm[@17~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-list.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 3)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-list.scm[@3~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-program-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-program.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-program-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-program.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-program-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-program.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-program-4 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 4)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-program.scm[@4~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-vector.scm[@1~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-vector-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-down)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-vector.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-down--scheme-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-down)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 3)
+		  (combobulate-drag-down)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-down/scheme-vector.scm[@3~after].scm")))))
 (ert-deftest combobulate-test-go-combobulate-drag-down--switch-1 ()
  "Test `combobulate' with `fixtures/sibling/switch.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-drag-up.gen.el
+++ b/tests/test-combobulate-drag-up.gen.el
@@ -1937,6 +1937,379 @@
 		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/python-tuple.py[@1~after].py")))))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-brace-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-brace-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-brace-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-brace-list.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-bracket-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-bracket-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-bracket-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-bracket-list.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-byte-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-byte-vector-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-byte-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-byte-vector.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-17 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 17)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@17~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-16 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 16)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@16~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-15 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 15)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@15~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-14 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 14)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@14~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-13 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 13)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@13~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-12 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 12)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@12~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-11 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 11)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@11~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-10 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 10)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@10~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-9 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 9)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@9~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-8 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 8)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@8~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-7 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 7)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@7~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-6 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 6)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@6~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-5 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 5)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@5~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-4 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@4~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-datums-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-datums.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-list.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-list-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-list.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-list.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-program-4 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-program.scm[@4~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-program-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-program.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-program-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-program.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-program-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-program.scm[@1~after].scm")))))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-vector.scm[@3~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-vector-2 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-drag-up)
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-vector.scm[@2~after].scm")))
+
+(ert-deftest combobulate-test-scheme-combobulate-drag-up--scheme-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-drag-up)
+	       (should-error
+		(progn
+		  (combobulate-test-go-to-marker 1)
+		  (combobulate-drag-up)
+		  (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-drag-up/scheme-vector.scm[@1~after].scm")))))
 (ert-deftest combobulate-test-go-combobulate-drag-up--switch-3 ()
  "Test `combobulate' with `fixtures/sibling/switch.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-kill-dwim.gen.el
+++ b/tests/test-combobulate-kill-dwim.gen.el
@@ -88,6 +88,18 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-kill-dwim/python-match-case.py[@1~after].py")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-kill-dwim--scheme-datums-1 ()
+ "Test `combobulate' with `fixtures/kill-node/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/kill-node/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-kill-dwim)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate--with-test-overlays
+		(lambda
+		  (ov)
+		  (combobulate-kill-node-dwim)))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-kill-dwim/scheme-datums.scm[@1~after].scm")))
 (ert-deftest combobulate-test-yaml-combobulate-kill-dwim--yaml-block-mapping-pairs-1 ()
  "Test `combobulate' with `fixtures/kill-node/yaml-block-mapping-pairs.yaml' in `yaml-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-navigate-down.gen.el
+++ b/tests/test-combobulate-navigate-down.gen.el
@@ -345,6 +345,147 @@
 	       (combobulate-test-assert-at-marker 9)))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-byte-vector-2 ()
+ "Test `combobulate' with `fixtures/down/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-list-delimiters-3 ()
+ "Test `combobulate' with `fixtures/down/scheme-list-delimiters.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-list-delimiters.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-list-4 ()
+ "Test `combobulate' with `fixtures/down/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-quasiquote-splicing-4 ()
+ "Test `combobulate' with `fixtures/down/scheme-quasiquote-splicing.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-quasiquote-splicing.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-quasiquote-unquote-4 ()
+ "Test `combobulate' with `fixtures/down/scheme-quasiquote-unquote.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-quasiquote-unquote.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-quasisyntax-splicing-4 ()
+ "Test `combobulate' with `fixtures/down/scheme-quasisyntax-splicing.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-quasisyntax-splicing.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-quasisyntax-unsyntax-4 ()
+ "Test `combobulate' with `fixtures/down/scheme-quasisyntax-unsyntax.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-quasisyntax-unsyntax.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-quote-3 ()
+ "Test `combobulate' with `fixtures/down/scheme-quote.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-quote.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-syntax-3 ()
+ "Test `combobulate' with `fixtures/down/scheme-syntax.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-syntax.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-down--scheme-vector-3 ()
+ "Test `combobulate' with `fixtures/down/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/down/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-down)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-down)
+	       (combobulate-test-assert-at-marker 3)))
 (ert-deftest combobulate-test-toml-combobulate-navigate-down--table-3 ()
  "Test `combobulate' with `fixtures/down/table.toml' in `toml-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-navigate-next.gen.el
+++ b/tests/test-combobulate-navigate-next.gen.el
@@ -701,6 +701,141 @@
 	       (combobulate-test-assert-at-marker 5)))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-brace-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-bracket-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-byte-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-datums-17 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 4)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 5)
+	       (combobulate-test-go-to-marker 5)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 6)
+	       (combobulate-test-go-to-marker 6)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 7)
+	       (combobulate-test-go-to-marker 7)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 8)
+	       (combobulate-test-go-to-marker 8)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 9)
+	       (combobulate-test-go-to-marker 9)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 10)
+	       (combobulate-test-go-to-marker 10)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 11)
+	       (combobulate-test-go-to-marker 11)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 12)
+	       (combobulate-test-go-to-marker 12)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 13)
+	       (combobulate-test-go-to-marker 13)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 14)
+	       (combobulate-test-go-to-marker 14)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 15)
+	       (combobulate-test-go-to-marker 15)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 16)
+	       (combobulate-test-go-to-marker 16)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 17)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-list-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-program-4 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 4)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-next--scheme-vector-3 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-next)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-next)
+	       (combobulate-test-assert-at-marker 3)))
 (ert-deftest combobulate-test-go-combobulate-navigate-next--switch-3 ()
  "Test `combobulate' with `fixtures/sibling/switch.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-navigate-previous.gen.el
+++ b/tests/test-combobulate-navigate-previous.gen.el
@@ -701,6 +701,141 @@
 	       (combobulate-test-assert-at-marker 1)))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-brace-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-brace-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-brace-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-bracket-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-bracket-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-bracket-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-byte-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-byte-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-byte-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-datums-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-datums.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-datums.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 16)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 15)
+	       (combobulate-test-go-to-marker 15)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 14)
+	       (combobulate-test-go-to-marker 14)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 13)
+	       (combobulate-test-go-to-marker 13)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 12)
+	       (combobulate-test-go-to-marker 12)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 11)
+	       (combobulate-test-go-to-marker 11)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 10)
+	       (combobulate-test-go-to-marker 10)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 9)
+	       (combobulate-test-go-to-marker 9)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 8)
+	       (combobulate-test-go-to-marker 8)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 7)
+	       (combobulate-test-go-to-marker 7)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 6)
+	       (combobulate-test-go-to-marker 6)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 5)
+	       (combobulate-test-go-to-marker 5)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 4)
+	       (combobulate-test-go-to-marker 4)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 3)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-list-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-program-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-program.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-program.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 3)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 2)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
+
+(ert-deftest combobulate-test-scheme-combobulate-navigate-previous--scheme-vector-1 ()
+ "Test `combobulate' with `fixtures/sibling/scheme-vector.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/sibling/scheme-vector.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-navigate-previous)
+	       (combobulate-test-go-to-marker 2)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-navigate-previous)
+	       (combobulate-test-assert-at-marker 1)))
 (ert-deftest combobulate-test-go-combobulate-navigate-previous--switch-1 ()
  "Test `combobulate' with `fixtures/sibling/switch.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-splice-self-offset-1.gen.el
+++ b/tests/test-combobulate-splice-self-offset-1.gen.el
@@ -32,6 +32,18 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-self-offset-1/choice-1-inside-case.go[@1~after].go")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-splice-self-offset-1--choice-1-scheme-list-1 ()
+ "Test `combobulate' with `fixtures/splice/choice-1-scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/splice/choice-1-scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-splice-self-offset-1)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(1 1 1 1 1 1 1))
+		 (combobulate-splice-self))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-self-offset-1/choice-1-scheme-list.scm[@1~after].scm")))
 (ert-deftest combobulate-test-go-combobulate-splice-self-offset-1--choice-1-switch-1 ()
  "Test `combobulate' with `fixtures/splice/choice-1-switch.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-splice-self.gen.el
+++ b/tests/test-combobulate-splice-self.gen.el
@@ -340,6 +340,18 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-self/choice-0-pairs-in-table.toml[@1~after].toml")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-splice-self--choice-0-scheme-list-1 ()
+ "Test `combobulate' with `fixtures/splice/choice-0-scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/splice/choice-0-scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-splice-self)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0 0 0))
+		 (combobulate-splice-self))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-self/choice-0-scheme-list.scm[@1~after].scm")))
 (ert-deftest combobulate-test-go-combobulate-splice-self--choice-0-vars-1 ()
  "Test `combobulate' with `fixtures/splice/choice-0-vars.go' in `go-ts-mode' mode."
 	     (combobulate-test

--- a/tests/test-combobulate-splice-up.gen.el
+++ b/tests/test-combobulate-splice-up.gen.el
@@ -340,6 +340,19 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/choice-0-pairs-in-table.toml[@1~after].toml")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-splice-up--choice-0-scheme-list-1 ()
+ "Test `combobulate' with `fixtures/splice/choice-0-scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/splice/choice-0-scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-splice-up)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0 0 0))
+		 (combobulate-splice-up))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/choice-0-scheme-list.scm[@1~after].scm")))
+
 (ert-deftest combobulate-test-go-combobulate-splice-up--choice-0-vars-1 ()
  "Test `combobulate' with `fixtures/splice/choice-0-vars.go' in `go-ts-mode' mode."
 	     (combobulate-test
@@ -381,6 +394,19 @@
 		 (combobulate-splice-up))
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/choice-1-inside-case.go[@1~after].go")))
 
+
+(ert-deftest combobulate-test-scheme-combobulate-splice-up--choice-1-scheme-list-1 ()
+ "Test `combobulate' with `fixtures/splice/choice-1-scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/splice/choice-1-scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-splice-up)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0 0 0))
+		 (combobulate-splice-up))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/choice-1-scheme-list.scm[@1~after].scm")))
 
 (ert-deftest combobulate-test-go-combobulate-splice-up--choice-1-switch-1 ()
  "Test `combobulate' with `fixtures/splice/choice-1-switch.go' in `go-ts-mode' mode."
@@ -452,3 +478,15 @@
 	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/pairs-in-table.toml[@1~after].toml")))
 
 
+(ert-deftest combobulate-test-scheme-combobulate-splice-up--scheme-list-1 ()
+ "Test `combobulate' with `fixtures/splice/scheme-list.scm' in `scheme-mode' mode."
+	     (combobulate-test
+		 (:language scheme :mode scheme-mode :fixture "fixtures/splice/scheme-list.scm")
+	       :tags
+	       '(combobulate scheme scheme-mode combobulate-splice-up)
+	       (combobulate-test-go-to-marker 1)
+	       (combobulate-with-stubbed-proffer-choices
+		   (:choices
+		    '(0 0 0 0 0 0))
+		 (combobulate-splice-up))
+	       (combobulate-compare-action-with-fixture-delta "./fixture-deltas/combobulate-splice-up/scheme-list.scm[@1~after].scm")))

--- a/tests/test-edit-procedure.el
+++ b/tests/test-edit-procedure.el
@@ -144,6 +144,57 @@
     (should-not (combobulate-procedure-apply-has-parent
                  '("arrow_function") (combobulate-node-at-point '("jsx_expression"))))))
 
+(ert-deftest combobulate-nav-defun-node-p-honors-activation-constraints ()
+  :tags '(combobulate procedure)
+  (combobulate-test (:language json :mode json-ts-mode)
+    "[[1], 2]"
+    bob
+    (search-forward "1")
+    (backward-char)
+    (let* ((number (combobulate-node-at-point '("number")))
+           (inner (combobulate-node-parent number))
+           (outer (combobulate-node-parent inner))
+           (combobulate-default-procedures
+            '((:activation-nodes
+               ((:nodes ("array")
+                 :has-parent ("array")))))))
+      (should (equal (combobulate-node-type inner) "array"))
+      (should (equal (combobulate-node-type outer) "array"))
+      (should (combobulate-nav-defun-node-p inner))
+      (should-not (combobulate-nav-defun-node-p outer))
+      (should (combobulate-node-eq
+               inner (combobulate-nav-get-defun number))))))
+
+(ert-deftest combobulate-nav-defun-node-p-preserves-node-only-rules ()
+  :tags '(combobulate procedure)
+  (combobulate-test (:language json :mode json-ts-mode)
+    "[[1], 2]"
+    bob
+    (search-forward "1")
+    (backward-char)
+    (let* ((number (combobulate-node-at-point '("number")))
+           (inner (combobulate-node-parent number))
+           (outer (combobulate-node-parent inner))
+           (combobulate-default-procedures
+            '((:activation-nodes ((:nodes ("array")))))))
+      (should (combobulate-nav-defun-node-p inner))
+      (should (combobulate-nav-defun-node-p outer))
+      (should (combobulate-node-eq
+               inner (combobulate-nav-get-defun number))))))
+
+(ert-deftest combobulate-nav-defun-node-p-ignores-selectors ()
+  :tags '(combobulate procedure)
+  (combobulate-test (:language json :mode json-ts-mode)
+    "[1]"
+    bob
+    (let ((array (combobulate-node-at-point '("array")))
+          (combobulate-default-procedures
+           '((:activation-nodes ((:nodes ("array")))
+              :selector (:choose node
+                         :match-children
+                         (:match-rules ("string")))))))
+      (should (combobulate-nav-defun-node-p array)))))
+
 (ert-deftest combobulate-procedure-apply-has-ancestor ()
   :tags '(combobulate procedure)
   ;; Simple string node test

--- a/tests/test-scheme.el
+++ b/tests/test-scheme.el
@@ -1,0 +1,317 @@
+;;; test-scheme.el --- Tests for Scheme support  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  coopi
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for structural Scheme navigation and editing.
+
+;;; Code:
+
+(require 'combobulate)
+(require 'combobulate-test-prelude)
+(require 'scheme)
+
+(defconst combobulate-test-scheme--datum-nodes
+  '("boolean"
+    "byte_vector"
+    "character"
+    "keyword"
+    "list"
+    "number"
+    "quasiquote"
+    "quasisyntax"
+    "quote"
+    "string"
+    "symbol"
+    "syntax"
+    "unquote"
+    "unquote_splicing"
+    "unsyntax"
+    "unsyntax_splicing"
+    "vector")
+  "Expected datum nodes for the supported Scheme grammar.")
+
+(defconst combobulate-test-scheme--compound-datum-nodes
+  '("byte_vector"
+    "list"
+    "quasiquote"
+    "quasisyntax"
+    "quote"
+    "syntax"
+    "unquote"
+    "unquote_splicing"
+    "unsyntax"
+    "unsyntax_splicing"
+    "vector")
+  "Expected compound datum nodes for the supported Scheme grammar.")
+
+(defun combobulate-test-scheme--goto (text)
+  "Move point to the beginning of TEXT in the current buffer."
+  (goto-char (point-min))
+  (search-forward text)
+  (goto-char (match-beginning 0)))
+
+(defun combobulate-test-scheme--buffer-string ()
+  "Return the current buffer without text properties."
+  (buffer-substring-no-properties (point-min) (point-max)))
+
+(ert-deftest combobulate-test-scheme-classic-mode-registration ()
+  "Classic `scheme-mode' resolves Scheme without an existing parser."
+  (with-temp-buffer
+    (scheme-mode)
+    (should-not (treesit-parser-list))
+    (should (eq (combobulate-primary-language t) 'scheme))))
+
+(ert-deftest combobulate-test-scheme-registration ()
+  "Scheme registers and activates its tree-sitter language."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(define answer 42)"
+    bob
+    (should (eq (combobulate-primary-language) 'scheme))
+    (should (combobulate-read minor-mode))))
+
+(ert-deftest combobulate-test-scheme-datum-rules ()
+  "Datum rules track every datum in the supported Scheme grammar."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "()"
+    (should
+     (equal
+      (sort (combobulate-procedure-expand-rules
+             combobulate-scheme--datum-rules)
+            #'string<)
+      (sort (copy-sequence combobulate-test-scheme--datum-nodes)
+            #'string<)))))
+
+(ert-deftest combobulate-test-scheme-compound-datum-rules ()
+  "Compound rules track every nestable datum in the Scheme grammar."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "()"
+    (should
+     (equal
+      (sort (combobulate-procedure-expand-rules
+             combobulate-scheme--compound-datum-rules)
+            #'string<)
+      (sort (copy-sequence combobulate-test-scheme--compound-datum-nodes)
+            #'string<)))))
+
+(ert-deftest combobulate-test-scheme-datum-tree-shapes ()
+  "The supported Scheme grammar parses every datum as expected."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(#t #vu8(1 2) #\\a #:keyword (nested) 42 `(quasi) \
+#`(quasisyntax) '(quoted) \"text\" symbol #'(syntax) ,unquote \
+,@splice #,unsyntax #,@unsplice #(vector))"
+    bob
+    (let ((node (combobulate-node-at-point '("list"))))
+      (should
+       (equal
+        (mapcar #'combobulate-node-type
+                (combobulate-node-children node))
+        combobulate-test-scheme--datum-nodes)))))
+
+(ert-deftest combobulate-test-scheme-sibling-navigation-discards-trivia ()
+  "Sibling navigation skips every structural trivia node."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(alpha ; line comment
+ #| block comment |# beta #;(ignored datum) gamma \
+#!fold-case delta)"
+    (combobulate-test-scheme--goto "alpha")
+    (dolist (expected '("beta" "gamma" "delta"))
+      (combobulate-navigate-next)
+      (should (looking-at-p expected)))
+    (dolist (expected '("gamma" "beta" "alpha"))
+      (combobulate-navigate-previous)
+      (should (looking-at-p expected)))))
+
+(ert-deftest combobulate-test-scheme-logical-navigation ()
+  "Logical navigation moves forward and backward between Scheme nodes."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "alpha beta gamma"
+    bob
+    (combobulate-navigate-logical-next)
+    (should (looking-at-p "beta"))
+    (combobulate-navigate-logical-next)
+    (should (looking-at-p "gamma"))
+    (combobulate-navigate-logical-previous)
+    (should (looking-at-p "beta"))
+    (combobulate-navigate-logical-previous)
+    (should (looking-at-p "alpha"))))
+
+(ert-deftest combobulate-test-scheme-hierarchy-up ()
+  "Hierarchy navigation climbs through compound reader forms."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "#('(leaf))"
+    (combobulate-test-scheme--goto "leaf")
+    (combobulate-navigate-up)
+    (should (looking-at-p "(leaf"))
+    (combobulate-navigate-up)
+    (should (looking-at-p "'(leaf"))
+    (combobulate-navigate-up)
+    (should (looking-at-p "#("))))
+
+(ert-deftest combobulate-test-scheme-defun-procedure-is-structural ()
+  "Only top-level datums satisfy Scheme defun procedures."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(outer (inner leaf))\nnext"
+    (with-navigation-nodes (:procedures (combobulate-read procedures-defun))
+      (combobulate-test-scheme--goto "outer")
+      (let ((outer (combobulate-node-parent
+                    (combobulate-node-at-point))))
+        (should (combobulate-nav-defun-node-p outer)))
+      (combobulate-test-scheme--goto "inner")
+      (let ((inner (combobulate-node-parent
+                    (combobulate-node-at-point))))
+        (should-not (combobulate-nav-defun-node-p inner)))
+      (combobulate-test-scheme--goto "leaf")
+      (should
+       (equal (combobulate-node-text (combobulate-nav-get-defun))
+              "(outer (inner leaf))")))))
+
+(ert-deftest combobulate-test-scheme-defun-activation-contract ()
+  "Defun identity uses activation rules without changing old node rules."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(outer (inner leaf))"
+    (combobulate-test-scheme--goto "inner")
+    (let* ((inner (combobulate-node-parent
+                   (combobulate-node-at-point)))
+           (outer (combobulate-node-parent inner)))
+      (let ((combobulate-default-procedures
+             '((:activation-nodes ((:nodes ("list")))))))
+        (should (combobulate-nav-defun-node-p inner))
+        (should (combobulate-nav-defun-node-p outer)))
+      (let ((combobulate-default-procedures
+             '((:activation-nodes
+                ((:nodes ("list") :has-parent ("program")))
+                :selector
+                (:choose node
+                 :match-children (:match-rules ("number")))))))
+        (should-not (combobulate-nav-defun-node-p inner))
+        (should (combobulate-nav-defun-node-p outer))))))
+
+(ert-deftest combobulate-test-scheme-defun-navigation ()
+  "Defun navigation uses top-level datums from nested positions."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "first\n(outer (inner leaf))\nlast"
+    (combobulate-test-scheme--goto "(outer")
+    (let ((expected-start (point))
+          (expected-end (scan-sexps (point) 1)))
+      (combobulate-test-scheme--goto "leaf")
+      (combobulate-navigate-beginning-of-defun)
+      (should (= (point) expected-start))
+      (combobulate-test-scheme--goto "leaf")
+      (combobulate-navigate-end-of-defun)
+      (should (= (point) expected-end)))))
+
+(ert-deftest combobulate-test-scheme-mark-defun ()
+  "Marking a defun selects the containing top-level datum."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "first\n(outer (inner leaf))\nlast"
+    (combobulate-test-scheme--goto "(outer")
+    (let ((expected-start (point))
+          (expected-end (scan-sexps (point) 1)))
+      (combobulate-test-scheme--goto "leaf")
+      (combobulate-mark-defun)
+      (should (= (region-beginning) expected-start))
+      (should (= (region-end) expected-end)))))
+
+(ert-deftest combobulate-test-scheme-sexp-navigation ()
+  "S-expression navigation moves over complete reader datums."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "'(alpha #(beta gamma)) #vu8(1 2) omega"
+    bob
+    (let ((first-end (save-excursion
+                       (search-forward "'(alpha #(beta gamma))"))))
+      (combobulate-forward-sexp-function 1)
+      (should (= (point) first-end)))
+    (combobulate-skip-whitespace-forward t)
+    (let ((second-start (point))
+          (second-end (save-excursion
+                        (search-forward "#vu8(1 2)"))))
+      (combobulate-forward-sexp-function 1)
+      (should (= (point) second-end))
+      (combobulate-forward-sexp-function -1)
+      (should (= (point) second-start)))))
+
+(ert-deftest combobulate-test-scheme-transpose-sexps ()
+  "Transposing swaps adjacent Scheme datums."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(aaa bbb ccc)"
+    (combobulate-test-scheme--goto "bbb")
+    (combobulate-transpose-sexps)
+    (should (equal (combobulate-test-scheme--buffer-string)
+                   "(bbb aaa ccc)"))))
+
+(ert-deftest combobulate-test-scheme-mark-node-dwim ()
+  "DWIM marking selects the nearest Scheme datum first."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(aaa bbb ccc)"
+    (let ((combobulate-mark-node-or-thing-at-point nil))
+      (combobulate-test-scheme--goto "bbb")
+      (combobulate-mark-node-dwim 1 nil t)
+      (should (equal (buffer-substring-no-properties
+                      (region-beginning) (region-end))
+                     "bbb")))))
+
+(ert-deftest combobulate-test-scheme-splice-down ()
+  "Splice-down preserves the selected datum and preceding siblings."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(outer (inner aaa bbb ccc) tail)"
+    (combobulate-test-scheme--goto "bbb")
+    (combobulate-with-stubbed-proffer-choices (:choices '(0))
+      (combobulate-splice-down))
+    (should (equal (combobulate-test-scheme--buffer-string)
+                   "(outer inner aaa bbb tail)"))))
+
+(ert-deftest combobulate-test-scheme-splice-parent ()
+  "Splice-parent preserves all children of the removed parent."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "(outer (inner aaa bbb ccc) tail)"
+    (combobulate-test-scheme--goto "bbb")
+    (combobulate-with-stubbed-proffer-choices (:choices '(0))
+      (combobulate-splice-parent))
+    (should (equal (combobulate-test-scheme--buffer-string)
+                   "(outer inner aaa bbb ccc tail)"))))
+
+(ert-deftest combobulate-test-scheme-parentheses-envelope-node ()
+  "The default parentheses envelope wraps an applicable Scheme datum."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "alpha beta gamma"
+    (combobulate-test-scheme--goto "beta")
+    (let* ((node (combobulate-node-at-point '("symbol")))
+           (envelope (combobulate-get-envelope-by-name "wrap-parentheses")))
+      (should
+       (seq-some
+        (lambda (candidate)
+          (combobulate-node-eq node candidate))
+        (combobulate-envelope-get-applicable-nodes envelope)))
+      (combobulate-execute-envelope "wrap-parentheses" node))
+    (should (equal (combobulate-test-scheme--buffer-string)
+                   "alpha (beta) gamma"))))
+
+(ert-deftest combobulate-test-scheme-parentheses-envelope-region ()
+  "The default parentheses envelope wraps an active Scheme region."
+  (combobulate-test (:language scheme :mode scheme-mode)
+    "alpha beta gamma delta"
+    (combobulate-test-scheme--goto "beta")
+    (set-mark (point))
+    (search-forward "gamma")
+    (activate-mark)
+    (combobulate-execute-envelope "wrap-parentheses")
+    (should (equal (combobulate-test-scheme--buffer-string)
+                   "alpha (beta gamma) delta"))))
+
+(provide 'test-scheme)
+;;; test-scheme.el ends here


### PR DESCRIPTION
haiii!!  this PR adds Scheme support to combobulate!! :3

okay so.  `tree-sitter-scheme` is a little different from most of the grammars combobulate supports... it keeps Scheme nice and structural.  things like `define`, `lambda`, and `let` are all represented as datums and lists, which ends up fitting combobulate really nicely.

the support follows that structure directly.  top-level datums are defuns, list/vector elements are siblings, nested datums form the hierarchy, and quote/quasiquote/etc. remain proper structural nodes.  this also means Guile forms, macros, and whatever weird little defining form someone invents tomorrow work without needing special cases.

there are two commits here.

the first one fixes a small thing Scheme happened to expose.  `procedures-defun` could already say something like:

```elisp
(:nodes ("list")
 :has-parent ("program"))
```

but defun navigation only used the node type part of the rule, so the `:has-parent` constraint got lost along the way.

that's mostly invisible in grammars with nodes like `function_definition`, but Scheme just has `list`, so suddenly every nested call looks like a defun.

the fix makes defun navigation and marking check the complete procedure rule.  there's no new DSL syntax and nothing Scheme-specific in the core change; it just makes the existing constraints apply consistently during defun operations.  there's also a language-independent regression test for it.

the second commit adds the actual Scheme support: the language definition, generated grammar relationships, tree-sitter setup, and tests.

for defun navigation, an outermost datum is treated as a defun.  this feels very Scheme-y to me, and it means things like `define-syntax`, Guile's extra forms, and user-defined macros all behave naturally without combobulate needing to know what any of them mean.

the tests cover sibling, hierarchy, logical, sexp, and defun navigation, plus vectors, quotation forms, comments, marking, and macro-ish top-level forms.